### PR TITLE
fix some bugs

### DIFF
--- a/src/main/kotlin/fr/shikkanime/converters/config/ConfigToConfigDtoConverter.kt
+++ b/src/main/kotlin/fr/shikkanime/converters/config/ConfigToConfigDtoConverter.kt
@@ -3,7 +3,6 @@ package fr.shikkanime.converters.config
 import fr.shikkanime.converters.AbstractConverter
 import fr.shikkanime.dtos.ConfigDto
 import fr.shikkanime.entities.Config
-import fr.shikkanime.utils.StringUtils
 
 class ConfigToConfigDtoConverter : AbstractConverter<Config, ConfigDto>() {
     @Converter

--- a/src/test/kotlin/fr/shikkanime/jobs/UpdateAnimeJobTest.kt
+++ b/src/test/kotlin/fr/shikkanime/jobs/UpdateAnimeJobTest.kt
@@ -205,4 +205,54 @@ class UpdateAnimeJobTest : AbstractTest() {
             anime.description
         )
     }
+
+    @Test
+    fun `run old ADN and Crunchyroll anime One Piece Log`() {
+        val zonedDateTime = ZonedDateTime.parse("2024-11-03T08:00:00Z")
+
+        val tmpAnime = animeService.save(
+            Anime(
+                countryCode = CountryCode.FR,
+                releaseDateTime = zonedDateTime,
+                lastReleaseDateTime = zonedDateTime,
+                lastUpdateDateTime = zonedDateTime,
+                name = "ONE PIECE Log: Fish-Man Island Saga",
+                slug = "one-piece-log",
+                image = "https://www.crunchyroll.com/imgsrv/display/thumbnail/1560x2340/catalog/crunchyroll/757bae5a21039bac6ebace5de9affcd8.jpg",
+                banner = "https://www.crunchyroll.com/imgsrv/display/thumbnail/1920x1080/catalog/crunchyroll/a249096c7812deb8c3c2c907173f3774.jpg",
+            )
+        )
+
+        animePlatformService.save(
+            AnimePlatform(
+                anime = tmpAnime,
+                platform = Platform.ANIM,
+                platformId = "1260"
+            )
+        )
+
+        animePlatformService.save(
+            AnimePlatform(
+                anime = tmpAnime,
+                platform = Platform.CRUN,
+                platformId = "GRMG8ZQZR"
+            )
+        )
+
+        updateAnimeJob.run()
+
+        val animes = animeService.findAll()
+        assertEquals(1, animes.size)
+        val anime = animes.first()
+
+        assumeTrue("https://image.animationdigitalnetwork.fr/license/onepiecefishmansaga/tv/web/affiche_350x500.jpg" == anime.image)
+        assertEquals(
+            "https://image.animationdigitalnetwork.fr/license/onepiecefishmansaga/tv/web/license_640x360.jpg",
+            anime.banner
+        )
+        assertEquals(
+            "Après deux ans de séparation, le grand jour est enfin arrivé : l’équipage du Chapeau de paille se réunit à nouveau sur l’archipel Sabaody. Forts de leur expérience et prêts à affronter le Nouveau Monde, ils se préparent à naviguer sous l’eau, avec un Thousand Sunny désormais équipé pour atteindre leur prochaine destination : l’Île des Hommes-Poissons, un paradis sous-marin à plus de 10 000 mètres de profondeur !",
+            anime.description
+        )
+    }
 }


### PR DESCRIPTION
This pull request includes several changes to the `UpdateAnimeJob` and `UpdateEpisodeMappingJob` classes, as well as a new test in `UpdateAnimeJobTest`. The most important changes involve adding a new field to the `UpdatableAnime` class, modifying the sorting logic for updated animes, and enhancing the episode update logic.

Changes to `UpdateAnimeJob`:

* Added `episodeSize` field to the `UpdatableAnime` class.
* Modified sorting logic to prioritize `lastReleaseDateTime`, then `episodeSize`, and finally `sortIndex`.
* Updated the `fetchADNAnime` method to include `episodeSize` and use the maximum `releaseDate` from `showVideos` for `lastReleaseDateTime`.
* Added `episodeSize` to the `UpdatableAnime` instance in the `fetchCrunchyrollAnime` method.

Changes to `UpdateEpisodeMappingJob`:

* Refactored the filtering and distinct logic for episodes to improve readability and efficiency.
* Updated the `save` method call to remove the unnecessary `null` argument.
* Enhanced the logic for updating episode mappings to handle image updates and use the appropriate wrapper (cached or not) based on the update type. [[1]](diffhunk://#diff-1d69971c967443d47d35d13c8b5bcf3a427f0c715ef324fb581e893e4e7eaceaR341-R354) [[2]](diffhunk://#diff-1d69971c967443d47d35d13c8b5bcf3a427f0c715ef324fb581e893e4e7eaceaL358-R369) [[3]](diffhunk://#diff-1d69971c967443d47d35d13c8b5bcf3a427f0c715ef324fb581e893e4e7eaceaR386-R407)

New test in `UpdateAnimeJobTest`:

* Added a test case to verify the behavior of the `UpdateAnimeJob` for old ADN and Crunchyroll anime, specifically for "ONE PIECE Log: Fish-Man Island Saga".