### PR TITLE
Refactor and centralize `getVideoOldIdOrId` to `StringUtils`

### DIFF
--- a/src/main/kotlin/fr/shikkanime/platforms/AnimationDigitalNetworkPlatform.kt
+++ b/src/main/kotlin/fr/shikkanime/platforms/AnimationDigitalNetworkPlatform.kt
@@ -180,7 +180,4 @@ class AnimationDigitalNetworkPlatform :
             else -> throw Exception("Language is null")
         }
     }
-
-    fun getAnimationDigitalNetworkId(identifier: String) =
-        "[A-Z]{2}-ANIM-([0-9]{1,5})-[A-Z]{2}-[A-Z]{2}(?:-UNC)?".toRegex().find(identifier)?.groupValues?.get(1)
 }

--- a/src/main/kotlin/fr/shikkanime/platforms/CrunchyrollPlatform.kt
+++ b/src/main/kotlin/fr/shikkanime/platforms/CrunchyrollPlatform.kt
@@ -106,7 +106,7 @@ class CrunchyrollPlatform : AbstractPlatform<CrunchyrollConfiguration, CountryCo
             previousWeekLocalDate.atEndOfTheDay(Constant.utcZoneId)
         ).filter { (_, releaseDateTime) -> previousWeek.isAfterOrEqual(releaseDateTime) }
             .forEach { (identifier, _) ->
-                val crunchyrollId = getCrunchyrollId(identifier) ?: run {
+                val crunchyrollId = StringUtils.getVideoOldIdOrId(identifier) ?: run {
                     logger.warning("Crunchyroll ID not found in $identifier")
                     return@forEach
                 }
@@ -164,9 +164,6 @@ class CrunchyrollPlatform : AbstractPlatform<CrunchyrollConfiguration, CountryCo
             }.getOrNull()?.firstOrNull()
         }
     }
-
-    fun getCrunchyrollId(identifier: String) =
-        "[A-Z]{2}-CRUN-([A-Z0-9]{9})-[A-Z]{2}-[A-Z]{2}".toRegex().find(identifier)?.groupValues?.get(1)
 
     fun convertEpisode(
         countryCode: CountryCode,

--- a/src/main/kotlin/fr/shikkanime/platforms/DisneyPlusPlatform.kt
+++ b/src/main/kotlin/fr/shikkanime/platforms/DisneyPlusPlatform.kt
@@ -59,9 +59,6 @@ class DisneyPlusPlatform : AbstractPlatform<DisneyPlusConfiguration, CountryCode
         return list
     }
 
-    fun getVideoOldIdOrId(identifier: String) =
-        "[A-Z]{2}-DISN-(.*)-[A-Z]{2}-[A-Z]{2}".toRegex().find(identifier)?.groupValues?.get(1)
-
     fun convertEpisode(
         countryCode: CountryCode,
         episode: AbstractDisneyPlusWrapper.Episode,

--- a/src/main/kotlin/fr/shikkanime/platforms/NetflixPlatform.kt
+++ b/src/main/kotlin/fr/shikkanime/platforms/NetflixPlatform.kt
@@ -61,10 +61,6 @@ class NetflixPlatform : AbstractPlatform<NetflixConfiguration, CountryCodeNetfli
         return list
     }
 
-    fun getVideoOldIdOrId(identifier: String) =
-        "[A-Z]{2}-NETF-(.+)-[A-Z]{2}-[A-Z]{2}".toRegex().find(identifier)?.groupValues?.get(1)
-
-
     fun convertEpisode(
         countryCode: CountryCode,
         showImage: String,

--- a/src/main/kotlin/fr/shikkanime/platforms/PrimeVideoPlatform.kt
+++ b/src/main/kotlin/fr/shikkanime/platforms/PrimeVideoPlatform.kt
@@ -50,9 +50,6 @@ class PrimeVideoPlatform :
         return list
     }
 
-    fun getVideoOldIdOrId(identifier: String) =
-        "[A-Z]{2}-PRIM-(.+)-[A-Z]{2}-[A-Z]{2}".toRegex().find(identifier)?.groupValues?.get(1)
-
     fun convertEpisode(
         countryCode: CountryCode,
         showImage: String,

--- a/src/main/kotlin/fr/shikkanime/utils/StringUtils.kt
+++ b/src/main/kotlin/fr/shikkanime/utils/StringUtils.kt
@@ -162,6 +162,8 @@ object StringUtils {
         uncensored: Boolean = false
     ) = "${countryCode}-${platform}-$id-${audioLocale.uppercase()}${if (uncensored) "-UNC" else EMPTY_STRING}"
 
+    fun getVideoOldIdOrId(identifier: String) = "^[A-Z]{2}-[A-Z]{4}-(.+)-[A-Z]{2}-[A-Z]{2}(?:-UNC)?$".toRegex().find(identifier)?.groupValues?.get(1)
+
     fun generateRandomString(length: Int): String {
         val source = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
         return (1..length)


### PR DESCRIPTION
Streamlined the retrieval of video IDs across different platforms by centralizing the `getVideoOldIdOrId` logic in `StringUtils`. Removed platform-specific implementations to reduce redundancy and improve maintainability.