### PR TITLE
Make lastUpdateDateTime non-nullable and centralize default value

### DIFF
--- a/src/main/kotlin/fr/shikkanime/controllers/admin/api/AnimeController.kt
+++ b/src/main/kotlin/fr/shikkanime/controllers/admin/api/AnimeController.kt
@@ -12,6 +12,7 @@ import fr.shikkanime.entities.enums.Link
 import fr.shikkanime.factories.impl.AnimeFactory
 import fr.shikkanime.services.AnimeService
 import fr.shikkanime.services.AttachmentService
+import fr.shikkanime.utils.Constant
 import fr.shikkanime.utils.MapCache
 import fr.shikkanime.utils.routes.*
 import fr.shikkanime.utils.routes.method.Delete
@@ -38,7 +39,7 @@ class AnimeController : HasPageableRoute() {
     @AdminSessionAuthenticated
     private fun forceUpdateAllAnimes(): Response {
         val animes = animeService.findAll()
-        animes.forEach { it.lastUpdateDateTime = null }
+        animes.forEach { it.lastUpdateDateTime = Constant.oldLastUpdateDateTime }
         animeService.updateAll(animes)
 
         return Response.redirect(Link.ANIMES.href)

--- a/src/main/kotlin/fr/shikkanime/dtos/animes/AnimeDto.kt
+++ b/src/main/kotlin/fr/shikkanime/dtos/animes/AnimeDto.kt
@@ -15,7 +15,7 @@ data class AnimeDto(
     var slug: String,
     var releaseDateTime: String,
     val lastReleaseDateTime: String,
-    val lastUpdateDateTime: String?,
+    val lastUpdateDateTime: String,
     val description: String?,
     val simulcasts: Set<SimulcastDto>?,
     var audioLocales: Set<String>? = null,

--- a/src/main/kotlin/fr/shikkanime/entities/Anime.kt
+++ b/src/main/kotlin/fr/shikkanime/entities/Anime.kt
@@ -32,8 +32,8 @@ class Anime(
     var releaseDateTime: ZonedDateTime = ZonedDateTime.now(),
     @Column(nullable = false, name = "last_release_date_time")
     var lastReleaseDateTime: ZonedDateTime = releaseDateTime,
-    @Column(nullable = true, name = "last_update_date_time")
-    var lastUpdateDateTime: ZonedDateTime? = releaseDateTime,
+    @Column(nullable = false, name = "last_update_date_time")
+    var lastUpdateDateTime: ZonedDateTime = releaseDateTime,
     @Column(nullable = true, columnDefinition = "VARCHAR(2000)")
     var description: String? = null,
     @Column(nullable = false)

--- a/src/main/kotlin/fr/shikkanime/factories/impl/AnimeFactory.kt
+++ b/src/main/kotlin/fr/shikkanime/factories/impl/AnimeFactory.kt
@@ -39,7 +39,7 @@ class AnimeFactory : IGenericFactory<Anime, AnimeDto> {
             slug = entity.slug!!,
             releaseDateTime = entity.releaseDateTime.withUTCString(),
             lastReleaseDateTime = entity.lastReleaseDateTime.withUTCString(),
-            lastUpdateDateTime = entity.lastUpdateDateTime?.withUTCString(),
+            lastUpdateDateTime = entity.lastUpdateDateTime.withUTCString(),
             description = entity.description,
             simulcasts = if (Hibernate.isInitialized(entity.simulcasts)) entity.simulcasts.sortBySeasonAndYear().map { simulcastFactory.toDto(it) }.toSet() else null,
             audioLocales = audioLocales.takeIf { it.isNotEmpty() },

--- a/src/main/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJob.kt
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 class UpdateEpisodeMappingJob : AbstractJob {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val availableUpdatePlatforms = listOf(Platform.ANIM, Platform.CRUN, Platform.DISN, Platform.NETF, Platform.PRIM)
-    private val oldLastUpdateDateTime = ZonedDateTime.parse("2000-01-01T00:00:00Z")
 
     @Inject private lateinit var animeService: AnimeService
     @Inject private lateinit var episodeMappingService: EpisodeMappingService
@@ -135,7 +134,7 @@ class UpdateEpisodeMappingJob : AbstractJob {
         updateEpisodeDetails(originalEpisode, mapping, mappingIdentifier, hasChanged, needRefreshCache)
 
         mapping.lastUpdateDateTime = if (forceUpdate) {
-            oldLastUpdateDateTime
+            Constant.oldLastUpdateDateTime
         } else {
             zonedDateTime
         }
@@ -189,7 +188,7 @@ class UpdateEpisodeMappingJob : AbstractJob {
         needRefreshCache.set(true)
 
         episodeVariants.forEach {
-            it.mapping!!.lastUpdateDateTime = oldLastUpdateDateTime
+            it.mapping!!.lastUpdateDateTime = Constant.oldLastUpdateDateTime
             episodeMappingService.update(it.mapping!!)
         }
 

--- a/src/main/kotlin/fr/shikkanime/services/EpisodeVariantService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/EpisodeVariantService.kt
@@ -347,7 +347,7 @@ class EpisodeVariantService : AbstractService<EpisodeVariant, EpisodeVariantRepo
         val entity = EpisodeMapping(
             anime = mapping.anime,
             releaseDateTime = mapping.releaseDateTime,
-            lastUpdateDateTime = ZonedDateTime.parse("2000-01-01T00:00:00Z"),
+            lastUpdateDateTime = Constant.oldLastUpdateDateTime,
             episodeType = dto.episodeType,
             season = dto.season,
             number = dto.number,

--- a/src/main/kotlin/fr/shikkanime/services/admin/EpisodeMappingAdminService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/admin/EpisodeMappingAdminService.kt
@@ -11,6 +11,7 @@ import fr.shikkanime.entities.enums.EpisodeType
 import fr.shikkanime.entities.enums.ImageType
 import fr.shikkanime.entities.enums.LangType
 import fr.shikkanime.services.*
+import fr.shikkanime.utils.Constant
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.*
@@ -92,7 +93,7 @@ class EpisodeMappingAdminService {
                 ?.let { existingEpisode ->
                     mergeEpisodeMapping(episode, existingEpisode)?.apply {
                         lastUpdateDateTime = if (forcedUpdate) {
-                            ZonedDateTime.parse("2000-01-01T00:00:00Z")
+                            Constant.oldLastUpdateDateTime
                         } else {
                             ZonedDateTime.now()
                         }
@@ -215,7 +216,7 @@ class EpisodeMappingAdminService {
 
             // Update the episode
             episode.lastUpdateDateTime = if (forcedUpdate) {
-                ZonedDateTime.parse("2000-01-01T00:00:00Z") 
+                Constant.oldLastUpdateDateTime
             } else {
                 ZonedDateTime.now()
             }

--- a/src/main/kotlin/fr/shikkanime/utils/Constant.kt
+++ b/src/main/kotlin/fr/shikkanime/utils/Constant.kt
@@ -8,6 +8,7 @@ import fr.shikkanime.socialnetworks.AbstractSocialNetwork
 import org.reflections.Reflections
 import java.io.File
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import kotlin.io.path.createTempDirectory
 
 object Constant {
@@ -52,6 +53,7 @@ object Constant {
     val DEFAULT_IMAGE_PREVIEW = "$baseUrl/assets/img/episode_no_image_preview.jpg"
     const val DEFAULT_CACHE_DURATION = 31536000 // 1 year
     const val MAX_DESCRIPTION_LENGTH = 1_000
+    val oldLastUpdateDateTime = ZonedDateTime.parse("2000-01-01T00:00:00Z")
 
     init {
         abstractPlatforms.forEach {

--- a/src/main/resources/db/changelog/2025/04/03-changelog.xml
+++ b/src/main/resources/db/changelog/2025/04/03-changelog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <property global="false" name="id" value="1745500895890"/>
+    <property global="false" name="author" value="Ziedelth"/>
+
+    <changeSet id="${id}-1" author="${author}">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="anime" columnName="last_update_date_time"/>
+        </preConditions>
+
+        <addNotNullConstraint tableName="anime" columnName="last_update_date_time"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -96,4 +96,5 @@
     <!-- April 2025 -->
     <include file="/db/changelog/2025/04/01-changelog.xml"/>
     <include file="/db/changelog/2025/04/02-changelog.xml"/>
+    <include file="/db/changelog/2025/04/03-changelog.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Refactored the code to ensure `lastUpdateDateTime` is non-nullable across entities and DTOs. Centralized the default value into a `Constant` for consistency and replaced hardcoded instances. Added a database change log to enforce non-null constraint on `last_update_date_time` column.