### PR TITLE
Update RSS feed to use anime short name in titles

### DIFF
--- a/src/main/resources/templates/site/seo/rss.ftl
+++ b/src/main/resources/templates/site/seo/rss.ftl
@@ -9,7 +9,7 @@
         <link>${baseUrl}</link>
         <#list groupedEpisodes as groupedEpisode>
         <item>
-            <title>${groupedEpisode.anime.name?html} - ${su.toEpisodeGroupedString(groupedEpisode, true, false)}<#if groupedEpisode.title??> - ${groupedEpisode.title?html}</#if></title>
+            <title>${groupedEpisode.anime.shortName?html} - ${su.toEpisodeGroupedString(groupedEpisode, true, false)}<#if groupedEpisode.title??> - ${groupedEpisode.title?html}</#if></title>
             <description>${(groupedEpisode.description!"")?html}</description>
             <pubDate>${groupedEpisode.releaseDateTime?replace("Z", "+0000")}</pubDate>
             <lastBuildDate>${groupedEpisode.releaseDateTime?replace("Z", "+0000")}</lastBuildDate>


### PR DESCRIPTION
Replaced the use of full anime names with their short names in RSS feed titles. This change improves readability and ensures titles are more concise for users.