### PR TITLE
Add email sending functionality and cleanup template handling

### DIFF
--- a/src/main/kotlin/fr/shikkanime/entities/enums/Link.kt
+++ b/src/main/kotlin/fr/shikkanime/entities/enums/Link.kt
@@ -21,6 +21,7 @@ enum class Link(
     MEMBERS("$ADMIN/members", "/admin/members/list.ftl", "bi bi-people", "Members"),
     RULES("$ADMIN/rules", "/admin/rules.ftl", "bi bi-rulers", "Rules"),
     JOBS("$ADMIN/jobs", "/admin/jobs.ftl", "bi bi-gear-wide-connected", "Jobs"),
+    EMAILS("$ADMIN/emails", "/admin/emails.ftl", "bi bi-envelope", "Emails"),
     THREADS("$ADMIN/threads", "/admin/threads.ftl", "bi bi-threads", "Threads"),
     CONFIG("$ADMIN/config", "/admin/configs.ftl", "bi bi-gear", "Configurations"),
 

--- a/src/main/kotlin/fr/shikkanime/services/MailService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MailService.kt
@@ -3,6 +3,10 @@ package fr.shikkanime.services
 import com.google.inject.Inject
 import fr.shikkanime.entities.Mail
 import fr.shikkanime.repositories.MailRepository
+import fr.shikkanime.utils.Constant
+import freemarker.cache.ClassTemplateLoader
+import freemarker.template.Configuration
+import java.io.StringWriter
 
 class MailService : AbstractService<Mail, MailRepository>() {
     @Inject
@@ -11,4 +15,22 @@ class MailService : AbstractService<Mail, MailRepository>() {
     override fun getRepository() = mailRepository
 
     fun findAllNotSent() = mailRepository.findAllNotSent()
+
+    fun getFreemarkerContent(template: String, code: String? = null, model: Map<String, String>? = null): StringWriter {
+        val stringWriter = StringWriter()
+        val configuration = Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS)
+        configuration.templateLoader = ClassTemplateLoader(this::class.java.classLoader, "templates")
+        configuration.defaultEncoding = "UTF-8"
+
+        configuration.getTemplate(template).process(
+            mutableMapOf(
+                "baseUrl" to Constant.baseUrl,
+                "code" to code,
+            ).apply {
+                model?.let(this::putAll)
+            }, stringWriter
+        )
+
+        return stringWriter
+    }
 }

--- a/src/main/resources/templates/admin/emails.ftl
+++ b/src/main/resources/templates/admin/emails.ftl
@@ -1,0 +1,43 @@
+
+<#import "_navigation.ftl" as navigation />
+
+<@navigation.display>
+    <form action="${baseUrl}/admin/emails" method="post" id="emailForm">
+        <div class="d-flex justify-content-end">
+            <button type="button" class="btn btn-primary mt-3" data-bs-toggle="modal" data-bs-target="#confirmSendModal">Send</button>
+        </div>
+
+        <div class="card mt-3">
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-md-12">
+                        <label for="subject" class="form-label">Subject</label>
+                        <input type="text" class="form-control" id="subject" name="subject">
+                    </div>
+                    <div class="col-md-12">
+                        <label for="body" class="form-label">Body</label>
+                        <textarea id="body" name="body" class="form-control" rows="5" placeholder="Body"></textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+
+    <div class="modal fade" id="confirmSendModal" tabindex="-1" aria-labelledby="confirmSendModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="confirmSendModalLabel">Confirm</h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    Are you sure you want to send this email to all members?
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" onclick="document.getElementById('emailForm').submit();">Confirm</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</@navigation.display>

--- a/src/main/resources/templates/mail/_layout.ftl
+++ b/src/main/resources/templates/mail/_layout.ftl
@@ -1,4 +1,4 @@
-<#macro main title="" description="" showCode=true>
+<#macro main title="" description="" showCode=true showThanks=true>
     <div style="font-family: Arial, sans-serif; margin: 0; padding: 0; box-sizing: border-box; width: 100%; background-color: #f5f5f5;">
         <table role="presentation" style="width: 100%; border-collapse: collapse; background-color: #f5f5f5; margin: 0 auto;">
             <tr>
@@ -34,17 +34,19 @@
                         </#if>
 
                         <#if description?? && description?length != 0>
-                            <div style="font-size: 14px; color: #666666; margin-bottom: 25px; line-height: 1.5;">
+                            <div style="font-size: 14px; <#if title?? && title?length != 0 && showCode && code?? && code?length != 0>color: #666666;</#if> margin-bottom: 25px; line-height: 1.5;">
                                 ${description}
                             </div>
                         </#if>
 
                         <#nested />
 
-                        <p style="font-size: 16px; margin-bottom: 20px; line-height: 1.5;">
-                            Merci d'utiliser notre application ! Nous apprécions votre confiance et espérons que notre
-                            service répondra à vos attentes.
-                        </p>
+                        <#if showThanks>
+                            <p style="font-size: 16px; margin-bottom: 20px; line-height: 1.5;">
+                                Merci d'utiliser notre application ! Nous apprécions votre confiance et espérons que notre
+                                service répondra à vos attentes.
+                            </p>
+                        </#if>
 
                         <p style="font-size: 12px; color: #999999; margin: 0; border-top: 1px solid #eeeeee; padding-top: 15px;">
                             Ceci est un email automatique, merci de ne pas répondre.

--- a/src/main/resources/templates/mail/custom-message.ftl
+++ b/src/main/resources/templates/mail/custom-message.ftl
@@ -1,0 +1,7 @@
+<#import "_layout.ftl" as layout />
+
+<@layout.main
+description="${description}"
+showCode=false
+showThanks=false>
+</@layout.main>

--- a/src/main/resources/templates/site/privacy.ftl
+++ b/src/main/resources/templates/site/privacy.ftl
@@ -3,65 +3,43 @@
 <@navigation.display canonicalUrl="${baseUrl}/privacy">
     <div class="container mt-3">
         <h2>Politique de Confidentialité</h2>
-        <p><strong>Dernière mise à jour :</strong> 20 août 2024 à 9h</p>
+        <p><strong>Dernière mise à jour : </strong>25 avril 2025</p>
         <p><strong>1. Introduction</strong></p>
-        <p>Bienvenue sur Shikkanime ("nous", "notre" ou "nos"). Nous nous engageons à protéger la confidentialité de nos
-            utilisateurs ("vous"). Cette Politique de Confidentialité explique comment nous collectons, utilisons,
-            stockons et protégeons vos informations personnelles lorsque vous utilisez notre application mobile et notre
-            site web.</p>
+        <p>Bienvenue sur Shikkanime ("nous", "notre" ou "nos"). Nous nous engageons à protéger la confidentialité de nos utilisateurs ("vous"). Cette Politique de Confidentialité explique comment nous collectons, utilisons, stockons et protégeons vos informations personnelles lorsque vous utilisez notre application mobile et notre site web.</p>
         <p><strong>2. Données Collectées</strong></p>
         <p>Nous collectons les données suivantes lorsque vous utilisez notre application mobile et notre site web :</p>
         <ul>
             <li><strong>Adresse e-mail :</strong> utilisée pour la communication et l'envoi de notifications.</li>
-            <li><strong>ID utilisateur :</strong> utilisé pour identifier votre compte et personnaliser votre
-                expérience.
-            </li>
+            <li><strong>ID utilisateur :</strong> utilisé pour identifier votre compte et personnaliser votre expérience.</li>
+            <li><strong>Version de l'application :</strong> utilisée pour le dépannage et l'amélioration de l'application.</li>
+            <li><strong>Langue de l'appareil :</strong> utilisée pour adapter le contenu à votre langue préférée.</li>
+            <li><strong>Type d'appareil (iOS, Android, etc.) :</strong> utilisé pour optimiser l'expérience utilisateur selon la plateforme.</li>
         </ul>
         <p><strong>3. Utilisation des Données</strong></p>
         <p>Les données collectées sont utilisées dans les buts suivants :</p>
         <ul>
-            <li><strong>Communication :</strong> pour vous envoyer des informations importantes concernant votre compte
-                ou des notifications liées à l'utilisation de nos services.
-            </li>
-            <li><strong>Notifications :</strong> pour vous informer des mises à jour, des nouvelles fonctionnalités ou
-                d'autres informations pertinentes.
-            </li>
+            <li><strong>Communication :</strong> pour vous envoyer des informations importantes concernant votre compte ou des notifications liées à l'utilisation de nos services.</li>
+            <li><strong>Notifications :</strong> pour vous informer des mises à jour, des nouvelles fonctionnalités ou d'autres informations pertinentes.</li>
+            <li><strong>Amélioration du service :</strong> pour analyser l'utilisation de l'application, identifier les problèmes techniques et améliorer les fonctionnalités en fonction des appareils et des versions utilisées.</li>
+            <li><strong>Personnalisation :</strong> pour adapter l'interface et le contenu de l'application à la langue de votre appareil.</li>
         </ul>
         <p><strong>4. Partage des Données</strong></p>
-        <p>Nous ne partageons aucune de vos informations personnelles avec des tiers. Vos données sont strictement
-            utilisées dans le cadre de notre service et ne seront en aucun cas vendues, louées ou échangées avec des
-            tiers.</p>
+        <p>Nous ne partageons aucune de vos informations personnelles avec des tiers. Vos données sont strictement utilisées dans le cadre de notre service et ne seront en aucun cas vendues, louées ou échangées avec des tiers.</p>
         <p><strong>5. Sécurité des Données</strong></p>
-        <p>Nous prenons la sécurité de vos données très au sérieux. Les informations que vous nous fournissez sont
-            chiffrées et stockées de manière sécurisée. Nous mettons en œuvre des mesures de sécurité techniques et
-            organisationnelles appropriées pour protéger vos données contre tout accès non autorisé, toute modification,
-            divulgation ou destruction.</p>
+        <p>Nous prenons la sécurité de vos données très au sérieux. Les informations que vous nous fournissez sont chiffrées et stockées de manière sécurisée. Nous mettons en œuvre des mesures de sécurité techniques et organisationnelles appropriées pour protéger vos données contre tout accès non autorisé, toute modification, divulgation ou destruction.</p>
         <p><strong>6. Droits des Utilisateurs</strong></p>
         <p>Vous disposez des droits suivants concernant vos informations personnelles :</p>
         <ul>
-            <li><strong>Accès :</strong> Vous pouvez demander à consulter les informations personnelles que nous
-                détenons à votre sujet.
-            </li>
-            <li><strong>Rectification :</strong> Vous avez le droit de demander la correction de toute information
-                inexacte ou incomplète.
-            </li>
-            <li><strong>Suppression :</strong> Vous pouvez demander la suppression de vos informations personnelles de
-                nos systèmes.
-            </li>
+            <li><strong>Accès :</strong> Vous pouvez demander à consulter les informations personnelles que nous détenons à votre sujet.</li>
+            <li><strong>Rectification :</strong> Vous avez le droit de demander la correction de toute information inexacte ou incomplète.</li>
+            <li><strong>Suppression :</strong> Vous pouvez demander la suppression de vos informations personnelles de nos systèmes.</li>
         </ul>
-        <p>Pour exercer ces droits, veuillez nous contacter à l'adresse suivante :
-            <strong>contact@shikkanime.fr</strong>.</p>
+        <p>Pour exercer ces droits, veuillez nous contacter à l'adresse suivante : <strong>contact@shikkanime.fr</strong>.</p>
         <p><strong>7. Conservation des Données</strong></p>
-        <p>Nous conservons vos informations personnelles pendant une période de <strong>2 ans</strong> à partir de la
-            date de la dernière interaction avec nos services. Passé ce délai, vos données seront supprimées de manière
-            sécurisée, sauf si une conservation plus longue est requise par la loi.</p>
+        <p>Nous conservons vos informations personnelles pendant une période de <strong>deux ans</strong> à partir de la date de la dernière interaction avec nos services. Passé ce délai, vos données seront supprimées de manière sécurisée, sauf si une conservation plus longue est requise par la loi.</p>
         <p><strong>8. Modifications de la Politique de Confidentialité</strong></p>
-        <p>Nous pouvons mettre à jour cette Politique de Confidentialité de temps à autre. En cas de modification, nous
-            vous informerons par e-mail et via une notification sur notre site web et notre application. Nous vous
-            encourageons à consulter régulièrement cette page pour être informé des éventuels changements.</p>
+        <p>Nous pouvons mettre à jour cette Politique de Confidentialité de temps à autre. En cas de modification, nous vous informerons par e-mail et via une notification sur notre site web et notre application. Nous vous encourageons à consulter régulièrement cette page pour être informé des éventuels changements.</p>
         <p><strong>9. Contact</strong></p>
-        <p>Si vous avez des questions ou des préoccupations concernant cette Politique de Confidentialité ou le
-            traitement de vos données personnelles, veuillez nous contacter à l'adresse suivante : <strong>contact@shikkanime.fr</strong>.
-        </p>
+        <p>Si vous avez des questions ou des préoccupations concernant cette Politique de Confidentialité ou le traitement de vos données personnelles, veuillez nous contacter à l'adresse suivante : <strong>contact@shikkanime.fr</strong>.</p>
     </div>
 </@navigation.display>


### PR DESCRIPTION
Introduced admin email sending feature with template-based formatting. Centralized Freemarker template handling in `MailService` for reusability and removed duplicate logic. Updated privacy policy and templates for better language and layout consistency.