### PR TITLE
Add `findByIdentifier` method to improve episode lookup

### DIFF
--- a/src/main/kotlin/fr/shikkanime/platforms/NetflixPlatform.kt
+++ b/src/main/kotlin/fr/shikkanime/platforms/NetflixPlatform.kt
@@ -1,10 +1,12 @@
 package fr.shikkanime.platforms
 
+import com.google.inject.Inject
 import fr.shikkanime.caches.CountryCodeNetflixSimulcastKeyCache
 import fr.shikkanime.entities.enums.CountryCode
 import fr.shikkanime.entities.enums.EpisodeType
 import fr.shikkanime.entities.enums.Platform
 import fr.shikkanime.platforms.configuration.NetflixConfiguration
+import fr.shikkanime.services.caches.EpisodeVariantCacheService
 import fr.shikkanime.wrappers.factories.AbstractNetflixWrapper
 import fr.shikkanime.wrappers.impl.NetflixWrapper
 import java.io.File
@@ -12,6 +14,8 @@ import java.time.ZonedDateTime
 import java.util.logging.Level
 
 class NetflixPlatform : AbstractPlatform<NetflixConfiguration, CountryCodeNetflixSimulcastKeyCache, List<AbstractPlatform.Episode>>() {
+    @Inject private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
+
     override fun getPlatform(): Platform = Platform.NETF
 
     override fun getConfigurationClass() = NetflixConfiguration::class.java
@@ -39,7 +43,7 @@ class NetflixPlatform : AbstractPlatform<NetflixConfiguration, CountryCodeNetfli
 
                 // Apply delay if delay is defined for this locale
                 key.netflixSimulcast.audioLocaleDelays[audioLocale]?.let { delayInWeeks ->
-                    episode.releaseDateTime = episode.releaseDateTime.plusWeeks(delayInWeeks)
+                    episode.releaseDateTime = (episodeVariantCacheService.findByIdentifier(episode.getIdentifier())?.releaseDateTime ?: episode.releaseDateTime).plusWeeks(delayInWeeks)
                 }
                 // If no delay is applicable, the releaseDateTime set by convertEpisode is used.
 

--- a/src/main/kotlin/fr/shikkanime/repositories/EpisodeVariantRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/EpisodeVariantRepository.kt
@@ -175,4 +175,19 @@ class EpisodeVariantRepository : AbstractRepository<EpisodeVariant>() {
                 .map { it[0] as String to it[1] as ZonedDateTime }
         }
     }
+
+    fun findByIdentifier(identifier: String): EpisodeVariant? {
+        return database.entityManager.use {
+            val cb = it.criteriaBuilder
+
+            val query = cb.createQuery(getEntityClass())
+            val root = query.from(getEntityClass())
+
+            query.where(cb.equal(root[EpisodeVariant_.identifier], identifier))
+
+            createReadOnlyQuery(it, query)
+                .resultList
+                .firstOrNull()
+        }
+    }
 }

--- a/src/main/kotlin/fr/shikkanime/services/EpisodeVariantService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/EpisodeVariantService.kt
@@ -52,6 +52,8 @@ class EpisodeVariantService : AbstractService<EpisodeVariant, EpisodeVariantRepo
         endZonedDateTime
     )
 
+    fun findByIdentifier(identifier: String) = episodeVariantRepository.findByIdentifier(identifier)
+
     /**
      * Determines the appropriate simulcast for a given anime and episode mapping.
      *

--- a/src/main/kotlin/fr/shikkanime/services/caches/EpisodeVariantCacheService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/caches/EpisodeVariantCacheService.kt
@@ -21,14 +21,9 @@ import java.time.ZonedDateTime
 import java.util.*
 
 class EpisodeVariantCacheService : ICacheService {
-    @Inject
-    private lateinit var episodeVariantService: EpisodeVariantService
-
-    @Inject
-    private lateinit var memberCacheService: MemberCacheService
-
-    @Inject
-    private lateinit var episodeVariantFactory: EpisodeVariantFactory
+    @Inject private lateinit var episodeVariantService: EpisodeVariantService
+    @Inject private lateinit var memberCacheService: MemberCacheService
+    @Inject private lateinit var episodeVariantFactory: EpisodeVariantFactory
 
     fun findAllByMapping(episodeMapping: EpisodeMapping) = MapCache.getOrCompute(
         "EpisodeVariantCacheService.findAllByMapping",
@@ -85,4 +80,10 @@ class EpisodeVariantCacheService : ICacheService {
         classes = listOf(EpisodeVariant::class.java),
         key = uuid,
     ) { episodeVariantService.find(it)?.let { episodeVariantFactory.toDto(it) } }
+
+    fun findByIdentifier(identifier: String) = MapCache.getOrComputeNullable(
+        "EpisodeVariantCacheService.findByIdentifier",
+        classes = listOf(EpisodeVariant::class.java),
+        key = identifier,
+    ) { episodeVariantService.findByIdentifier(it) }
 }


### PR DESCRIPTION
Introduced the `findByIdentifier` method in `EpisodeVariantRepository`, `EpisodeVariantService`, and `EpisodeVariantCacheService` to facilitate streamlined retrieval of episodes by identifier. Updated `NetflixPlatform` to leverage cached release date logic for improved behavior with delays.