### PR TITLE
Handle movie-specific logic and improve Netflix data parsing

### DIFF
--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractNetflixWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractNetflixWrapper.kt
@@ -13,6 +13,8 @@ abstract class AbstractNetflixWrapper {
         val banner: String,
         val description: String?,
         val seasonCount: Int?,
+        val availabilityStartTime: ZonedDateTime?,
+        val runtimeSec: Long? = null,
     )
 
     data class Season(

--- a/src/test/kotlin/fr/shikkanime/platforms/NetflixPlatformTest.kt
+++ b/src/test/kotlin/fr/shikkanime/platforms/NetflixPlatformTest.kt
@@ -59,6 +59,22 @@ class NetflixPlatformTest : AbstractTest() {
                 imageUrl = "https://cdn.myanimelist.net/images/anime/1147/122444l.jpg",
                 audioLocales = setOf("ja-JP", "fr-FR"),
                 audioLocaleDelays = mapOf("fr-FR" to 1L)
+            ),
+            NetflixTestCase(
+                netflixId = "81208936",
+                expectedAnimeName = "Violet Evergarden : Éternité et la poupée de souvenirs automatiques",
+                releaseDay = 2,
+                testDate = "2025-04-29T21:30:00Z",
+                imageUrl = "https://cdn.myanimelist.net/images/anime/1425/102304l.jpg",
+                audioLocales = setOf("ja-JP", "fr-FR")
+            ),
+            NetflixTestCase(
+                netflixId = "81193214",
+                expectedAnimeName = "Violet Evergarden : Le film",
+                releaseDay = 2,
+                testDate = "2025-04-29T21:30:00Z",
+                imageUrl = "https://cdn.myanimelist.net/images/anime/1825/110716l.jpg",
+                audioLocales = setOf("ja-JP", "fr-FR")
             )
         )
     }


### PR DESCRIPTION
This commit adds support for handling movies in the Netflix wrapper by returning a single-episode structure and leveraging runtime and availability data. It also enhances parsing for high-resolution images and ensures default values for season count. Additionally, new test cases were added to validate these changes for both movies and series.