### PR TITLE
Add attachment support and improve member profile handling

### DIFF
--- a/src/main/kotlin/fr/shikkanime/dtos/member/DetailedMemberDto.kt
+++ b/src/main/kotlin/fr/shikkanime/dtos/member/DetailedMemberDto.kt
@@ -7,6 +7,7 @@ data class DetailedMemberDto(
     val email: String?,
     val creationDateTime: String,
     val lastUpdateDateTime: String?,
+    val attachmentLastUpdateDateTime: String?,
     val lastLoginDateTime: String?,
     val followedAnimesCount: Long,
     val followedEpisodesCount: Long,

--- a/src/main/kotlin/fr/shikkanime/entities/Member.kt
+++ b/src/main/kotlin/fr/shikkanime/entities/Member.kt
@@ -32,7 +32,12 @@ class Member(
     )
     @Enumerated(EnumType.STRING)
     val roles: MutableSet<Role> = mutableSetOf(),
+    // -----------------------------------------------------------------
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     var followedAnimes: MutableSet<MemberFollowAnime> = mutableSetOf(),
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "entity_uuid")
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    var attachments: MutableSet<Attachment> = mutableSetOf(),
 ) : ShikkEntity(uuid)

--- a/src/main/resources/templates/admin/episodes/edit.ftl
+++ b/src/main/resources/templates/admin/episodes/edit.ftl
@@ -194,7 +194,7 @@
                         <div class="col-md-6">
                             <label for="image" class="form-label">Image</label>
 
-                            <div class="input-group">
+                            <div class="input-group mb-2">
                                 <input type="text" class="form-control" id="image" name="image"
                                        x-model="episode.image" aria-label="Image"
                                        aria-describedby="basic-addon">
@@ -204,6 +204,8 @@
                                     <i class="bi bi-box-arrow-up-right"></i>
                                 </a>
                             </div>
+
+                            <img :src="'${apiUrl}/v1/attachments?uuid=' + episode.uuid + '&type=BANNER'" class="w-50" alt="Episode preview">
                         </div>
                         <div class="col-md-6">
                             <label for="duration" class="form-label">Duration</label>

--- a/src/main/resources/templates/admin/members/edit.ftl
+++ b/src/main/resources/templates/admin/members/edit.ftl
@@ -15,7 +15,7 @@
             <div class="card-body">
                 <div class="d-flex mb-3">
                     <template x-if="member.hasProfilePicture">
-                        <img x-bind:src="'/api/v1/attachments?uuid=' + member.uuid + '&type=MEMBER_PROFILE&v=' + new Date(member.lastUpdateDateTime).getTime()" class="rounded me-2" width="64" height="64" alt="Profile picture">
+                        <img x-bind:src="'/api/v1/attachments?uuid=' + member.uuid + '&type=MEMBER_PROFILE&v=' + new Date(member.attachmentLastUpdateDateTime).getTime()" class="rounded me-2" width="64" height="64" alt="Profile picture">
                     </template>
                     <div class="row row-cols-2">
                         <div class="col-auto">

--- a/src/main/resources/templates/admin/members/list.ftl
+++ b/src/main/resources/templates/admin/members/list.ftl
@@ -72,7 +72,7 @@
                 <tr>
                     <td>
                         <template x-if="member.hasProfilePicture">
-                            <img x-bind:src="'/api/v1/attachments?uuid=' + member.uuid + '&type=MEMBER_PROFILE&v=' + new Date(member.lastUpdateDateTime).getTime()" class="rounded-circle me-1" width="32" height="32" alt="Profile picture">
+                            <img x-bind:src="'/api/v1/attachments?uuid=' + member.uuid + '&type=MEMBER_PROFILE&v=' + new Date(member.attachmentLastUpdateDateTime).getTime()" class="rounded-circle me-1" width="32" height="32" alt="Profile picture">
                         </template>
 
                         <span class="me-1 badge" :class="member.isActive ? 'bg-success' : 'bg-danger'" x-text="member.isActive ? 'Active' : 'Inactive'"></span>


### PR DESCRIPTION
Introduced `attachments` field in the `Member` entity and updated repository queries to handle attachments efficiently. Adjusted templates to display profile pictures and episode banners based on their associated attachments' last update timestamp. This enhances flexibility and ensures up-to-date visuals across the application.