### PR TITLE
Fix incorrect variable usage in DisneyPlus episode retrieval

### DIFF
--- a/src/main/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJob.kt
@@ -440,7 +440,7 @@ class UpdateEpisodeMappingJob : AbstractJob {
             val id = StringUtils.getVideoOldIdOrId(episodeVariant.identifier!!) ?: return
             val ids = animePlatformService.findAllIdByAnimeAndPlatform(episodeMapping.anime!!, episodeVariant.platform!!)
             val checkAudioLocales = configCacheService.getValueAsBoolean(ConfigPropertyKey.CHECK_DISNEY_PLUS_AUDIO_LOCALES)
-            val platformEpisodes = ids.flatMap { DisneyPlusCachedWrapper.getEpisodesByShowId(countryCode.locale, id, checkAudioLocales) }
+            val platformEpisodes = ids.flatMap { DisneyPlusCachedWrapper.getEpisodesByShowId(countryCode.locale, it, checkAudioLocales) }
             val episode = platformEpisodes.find { it.id == id || it.oldId == id } ?: return
 
             updateIdentifier(episodeVariant, id, episode.id, identifiers)

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractDisneyPlusWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractDisneyPlusWrapper.kt
@@ -39,12 +39,6 @@ abstract class AbstractDisneyPlusWrapper {
         val audioLocales: Set<String>
     )
 
-    data class PlayerVideo(
-        val id: String,
-        val showId: String,
-        val resourceId: String
-    )
-
     protected val baseUrl = "https://disney.api.edge.bamgrid.com/"
     protected val httpRequest = HttpRequest()
 
@@ -88,7 +82,6 @@ abstract class AbstractDisneyPlusWrapper {
 
     abstract suspend fun getShow(id: String): Show
     abstract suspend fun getEpisodesByShowId(locale: String, showId: String, checkAudioLocales: Boolean): List<Episode>
-    abstract suspend fun getShowIdByEpisodeId(episodeId: String): PlayerVideo
     abstract suspend fun getAudioLocales(resourceId: String): Set<String>
 
     fun getImageUrl(id: String) = "https://disney.images.edge.bamgrid.com/ripcut-delivery/v2/variant/disney/$id/compose"

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/DisneyPlusWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/DisneyPlusWrapper.kt
@@ -100,33 +100,6 @@ object DisneyPlusWrapper : AbstractDisneyPlusWrapper() {
         return episodes
     }
 
-    override suspend fun getShowIdByEpisodeId(episodeId: String): PlayerVideo {
-        val types = listOf("deeplinkId", "dmcContentId")
-
-        val response = types.firstNotNullOfOrNull { type ->
-            val response = httpRequest.getWithAccessToken("${baseUrl}explore/v1.7/deeplink?action=playback&refId=$episodeId&refIdType=$type")
-
-            if (response.status == HttpStatusCode.OK) {
-                response
-            } else {
-                null
-            }
-        }
-
-        requireNotNull(response) { "Failed to fetch show id (${response?.status?.value})" }
-
-        val jsonObject = ObjectParser.fromJson(response.bodyAsText())
-            .getAsJsonObject("data")
-            .getAsJsonObject("deeplink")
-            .getAsJsonArray("actions")[0].asJsonObject
-
-        return PlayerVideo(
-            jsonObject.getAsString("deeplinkId")!!,
-            jsonObject.getAsJsonObject("partnerFeed").getAsString("evaSeriesEntityId")!!,
-            jsonObject.getAsString("resourceId")!!
-        )
-    }
-
     override suspend fun getAudioLocales(resourceId: String): Set<String> {
         val headers = mapOf(
             "x-application-version" to "1.1.2",

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/caches/DisneyPlusCachedWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/caches/DisneyPlusCachedWrapper.kt
@@ -25,12 +25,6 @@ object DisneyPlusCachedWrapper : AbstractDisneyPlusWrapper() {
         key = Triple(locale, showId, checkAudioLocales)
     ) { runBlocking { DisneyPlusWrapper.getEpisodesByShowId(it.first, it.second, it.third) } }
 
-    override suspend fun getShowIdByEpisodeId(episodeId: String) = MapCache.getOrCompute(
-        "DisneyPlusCachedWrapper.getShowIdByEpisodeId",
-        duration = defaultCacheDuration,
-        key = episodeId
-    ) { runBlocking { DisneyPlusWrapper.getShowIdByEpisodeId(it) } }
-
     override suspend fun getAudioLocales(resourceId: String) = MapCache.getOrCompute(
         "DisneyPlusCachedWrapper.getAudioLocales",
         duration = defaultCacheDuration,


### PR DESCRIPTION
Replaced 'id' with 'it' in the DisneyPlusCachedWrapper call to correctly iterate over IDs and retrieve platform episodes. This ensures accurate mapping of episodes and prevents potential mismatches or errors during the update process.