### PR TITLE
Refactor grouped episode retrieval with paginated query

### DIFF
--- a/src/main/kotlin/fr/shikkanime/entities/miscellaneous/GroupedEpisode.kt
+++ b/src/main/kotlin/fr/shikkanime/entities/miscellaneous/GroupedEpisode.kt
@@ -15,55 +15,11 @@ data class GroupedEpisode(
     val episodeType: EpisodeType,
     val minNumber: Int,
     val maxNumber: Int,
-    val platforms: Array<Platform>,
-    val audioLocales: Array<String>,
-    val urls: Array<String>,
-    val mappings: Array<UUID>,
+    val platforms: Set<Platform>,
+    val audioLocales: Set<String>,
+    val urls: Set<String>,
+    val mappings: Set<UUID>,
     var title: String? = null,
     var description: String? = null,
     var duration: Long? = null,
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is GroupedEpisode) return false
-
-        return minSeason == other.minSeason &&
-                maxSeason == other.maxSeason &&
-                minNumber == other.minNumber &&
-                maxNumber == other.maxNumber &&
-                duration == other.duration &&
-                anime == other.anime &&
-                releaseDateTime == other.releaseDateTime &&
-                lastUpdateDateTime == other.lastUpdateDateTime &&
-                episodeType == other.episodeType &&
-                platforms.contentEquals(other.platforms) &&
-                audioLocales.contentEquals(other.audioLocales) &&
-                urls.contentEquals(other.urls) &&
-                mappings.contentEquals(other.mappings) &&
-                title == other.title &&
-                description == other.description
-    }
-
-    override fun hashCode(): Int {
-        var result = minSeason
-        result = 31 * result + maxSeason
-        result = 31 * result + minNumber
-        result = 31 * result + maxNumber
-        result = 31 * result + (duration?.hashCode() ?: 0)
-        result = 31 * result + anime.hashCode()
-        result = 31 * result + releaseDateTime.hashCode()
-        result = 31 * result + lastUpdateDateTime.hashCode()
-        result = 31 * result + episodeType.hashCode()
-        result = 31 * result + platforms.contentHashCode()
-        result = 31 * result + audioLocales.contentHashCode()
-        result = 31 * result + urls.contentHashCode()
-        result = 31 * result + mappings.contentHashCode()
-        result = 31 * result + (title?.hashCode() ?: 0)
-        result = 31 * result + (description?.hashCode() ?: 0)
-        return result
-    }
-
-    override fun toString(): String {
-        return "GroupedEpisode(anime=$anime, releaseDateTime=$releaseDateTime, lastUpdateDateTime=$lastUpdateDateTime, minSeason=$minSeason, maxSeason=$maxSeason, episodeType=$episodeType, minNumber=$minNumber, maxNumber=$maxNumber, platforms=${platforms.contentToString()}, audioLocales=${audioLocales.contentToString()}, urls=${urls.contentToString()}, mappings=${mappings.contentToString()}, title=$title, description=$description, duration=$duration)"
-    }
-}
+)

--- a/src/main/kotlin/fr/shikkanime/services/EpisodeMappingService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/EpisodeMappingService.kt
@@ -13,17 +13,10 @@ import java.time.ZonedDateTime
 import java.util.*
 
 class EpisodeMappingService : AbstractService<EpisodeMapping, EpisodeMappingRepository>() {
-    @Inject
-    private lateinit var episodeMappingRepository: EpisodeMappingRepository
-
-    @Inject
-    private lateinit var episodeVariantService: EpisodeVariantService
-
-    @Inject
-    private lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var episodeMappingRepository: EpisodeMappingRepository
+    @Inject private lateinit var episodeVariantService: EpisodeVariantService
+    @Inject private lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
+    @Inject private lateinit var traceActionService: TraceActionService
 
     override fun getRepository() = episodeMappingRepository
 
@@ -48,7 +41,7 @@ class EpisodeMappingService : AbstractService<EpisodeMapping, EpisodeMappingRepo
     fun findAllSimulcasted(ignoreEpisodeTypes: Set<EpisodeType>, ignoreAudioLocale: String) =
         episodeMappingRepository.findAllSimulcasted(ignoreEpisodeTypes, ignoreAudioLocale)
 
-    fun findAllGrouped(countryCode: CountryCode) = episodeMappingRepository.findAllGrouped(countryCode)
+    fun findAllGroupedBy(countryCode: CountryCode, page: Int, limit: Int) = episodeMappingRepository.findAllGroupedBy(countryCode, page, limit)
 
     fun findLastNumber(anime: Anime, episodeType: EpisodeType, season: Int, platform: Platform, audioLocale: String) =
         episodeMappingRepository.findLastNumber(anime, episodeType, season, platform, audioLocale)

--- a/src/main/kotlin/fr/shikkanime/utils/MapCache.kt
+++ b/src/main/kotlin/fr/shikkanime/utils/MapCache.kt
@@ -26,8 +26,6 @@ class MapCache<K : Any, V>(
         return false
     }
 
-    fun lastInvalidation(key: K) = cache[key]?.first
-
     operator fun get(key: K): V? {
         val cachedValue = cache[key]
 
@@ -96,7 +94,5 @@ class MapCache<K : Any, V>(
             key: K,
             block: (K) -> V
         ) = getOrComputeNullable(name, duration, classes, key, block)!!
-
-        fun getCacheByName(name: String) = globalCaches[name]
     }
 }

--- a/src/test/kotlin/fr/shikkanime/controllers/api/v2/EpisodeMappingControllerTest.kt
+++ b/src/test/kotlin/fr/shikkanime/controllers/api/v2/EpisodeMappingControllerTest.kt
@@ -3,9 +3,7 @@ package fr.shikkanime.controllers.api.v2
 import fr.shikkanime.controllers.api.AbstractControllerTest
 import fr.shikkanime.dtos.PageableDto
 import fr.shikkanime.entities.enums.CountryCode
-import fr.shikkanime.entities.miscellaneous.GroupedEpisode
 import fr.shikkanime.module
-import fr.shikkanime.utils.MapCache
 import fr.shikkanime.utils.ObjectParser
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -25,8 +23,6 @@ class EpisodeMappingControllerTest : AbstractControllerTest() {
                 module()
             }
 
-            val now1 = System.currentTimeMillis()
-
             client.get("/api/v2/episode-mappings?country=${countryCode}&page=1&limit=4") {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             }.apply {
@@ -36,11 +32,6 @@ class EpisodeMappingControllerTest : AbstractControllerTest() {
                 assertTrue(episodeMappingsDto.total > 4)
             }
 
-            val cache1 = MapCache.getCacheByName("EpisodeMappingCacheService.findAllGrouped")!! as MapCache<CountryCode, List<GroupedEpisode>>
-            assertTrue(cache1.lastInvalidation(countryCode)!! > now1)
-
-            val now2 = System.currentTimeMillis()
-
             client.get("/api/v2/episode-mappings?country=${countryCode}&page=2&limit=8") {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             }.apply {
@@ -49,10 +40,6 @@ class EpisodeMappingControllerTest : AbstractControllerTest() {
                 assertEquals(8, episodeMappingsDto.data.size)
                 assertTrue(episodeMappingsDto.total > 8)
             }
-
-            val cache2 = MapCache.getCacheByName("EpisodeMappingCacheService.findAllGrouped")!! as MapCache<CountryCode, List<GroupedEpisode>>
-            assertTrue(cache2.lastInvalidation(countryCode)!! < now2)
-            assertTrue(cache2.lastInvalidation(countryCode)!! == cache1.lastInvalidation(countryCode))
         }
     }
 }


### PR DESCRIPTION
Replaced `findAllGrouped` with a paginated `findAllGroupedBy` method to improve performance. Updated the repository, service, and cache layers to use paginated queries and replaced arrays with sets in `GroupedEpisode` for better equality handling. Removed unused cache logic and optimized dependency injection formatting.