### PR TITLE
Add header support for member login and deprecate old routes

### DIFF
--- a/src/main/kotlin/fr/shikkanime/controllers/api/v2/MemberController.kt
+++ b/src/main/kotlin/fr/shikkanime/controllers/api/v2/MemberController.kt
@@ -12,16 +12,15 @@ import fr.shikkanime.utils.routes.param.BodyParam
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
+@Deprecated("Use /api/v1/members instead with headers")
 @Controller("/api/v2/members")
 class MemberController : HasPageableRoute() {
-    @Inject
-    private lateinit var memberService: MemberService
+    @Inject private lateinit var memberService: MemberService
 
     @Path("/login")
     @Post
     private fun loginMember(
-        @BodyParam
-        loginDto: LoginDto
+        @BodyParam loginDto: LoginDto
     ): Response {
         return Response.ok(memberService.login(loginDto.identifier, loginDto.appVersion, loginDto.device, loginDto.locale) ?: return runBlocking {
             delay(1000)

--- a/src/main/kotlin/fr/shikkanime/dtos/LoginDto.kt
+++ b/src/main/kotlin/fr/shikkanime/dtos/LoginDto.kt
@@ -1,5 +1,6 @@
 package fr.shikkanime.dtos
 
+@Deprecated("Use the new /v1/members/login endpoint")
 data class LoginDto(
     val identifier: String,
     val appVersion: String,

--- a/src/main/kotlin/fr/shikkanime/services/MemberService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MemberService.kt
@@ -95,7 +95,7 @@ class MemberService : AbstractService<Member, MemberRepository>() {
     fun login(identifier: String, appVersion: String? = null, device: String? = null, locale: String? = null): MemberDto? {
         val member = findByIdentifier(identifier) ?: return null
 
-        val traceData = if (appVersion != null && device != null && locale != null) {
+        val traceData = if (!appVersion.isNullOrBlank() && !device.isNullOrBlank() && !locale.isNullOrBlank()) {
             ObjectParser.toJson(mapOf(
                 "appVersion" to appVersion,
                 "device" to device,

--- a/src/main/kotlin/fr/shikkanime/utils/routes/param/HttpHeader.kt
+++ b/src/main/kotlin/fr/shikkanime/utils/routes/param/HttpHeader.kt
@@ -1,0 +1,5 @@
+package fr.shikkanime.utils.routes.param
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class HttpHeader(val name: String)

--- a/src/test/kotlin/fr/shikkanime/controllers/api/AbstractControllerTest.kt
+++ b/src/test/kotlin/fr/shikkanime/controllers/api/AbstractControllerTest.kt
@@ -42,6 +42,12 @@ abstract class AbstractControllerTest : AbstractTest() {
         }
 
         client.post("/api/v1/members/login") {
+            headers {
+                append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                append("X-App-Version", "1.0.0+1")
+                append("X-Device", "android")
+                append("X-Locale", "fr_FR")
+            }
             setBody(identifier!!)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)


### PR DESCRIPTION
This commit introduces support for reading headers (e.g., X-App-Version, X-Device, X-Locale) in the member login endpoint by creating a new `HttpHeader` annotation. It deprecates the `/v2/members` login route in favor of the updated `/v1/members/login` endpoint using headers. Refactored related code for improved readability and consistency.