### PR TITLE
Replace OpenCV WebP encoding with cwebp CLI-based conversion

### DIFF
--- a/.github/workflows/development_workflow.yml
+++ b/.github/workflows/development_workflow.yml
@@ -21,6 +21,8 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'corretto'
           cache: gradle
+      - name: Install Webp
+        run: sudo apt install -y webp
       - name: Analyze push
         if: github.event_name == 'push'
         env:

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -25,6 +25,8 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'corretto'
           cache: gradle
+      - name: Install Webp
+        run: sudo apt install -y webp
       - name: Build and test
         run: ./gradlew clean test --info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV LANG=C.UTF-8 \
 
 # Install necessary packages and set timezone
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl fonts-dejavu libopencv-dev tzdata \
+    && apt-get install -y --no-install-recommends ca-certificates curl fonts-dejavu tzdata webp \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
     && ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime \
     && echo "$TZ" > /etc/timezone \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ val quartzVersion = "2.5.0"
 val playwrightVersion = "1.51.0"
 val jsoupVersion = "1.20.1"
 val gsonVersion = "2.13.1"
-val openCvVersion = "4.9.0-0"
 val bcprovVersion = "1.80"
 val javaImageScalingVersion = "0.8.6"
 val firebaseVersion = "9.4.3"
@@ -87,7 +86,6 @@ dependencies {
     implementation("com.microsoft.playwright:playwright:$playwrightVersion")
     implementation("org.jsoup:jsoup:$jsoupVersion")
     implementation("com.google.code.gson:gson:$gsonVersion")
-    implementation("org.openpnp:opencv:$openCvVersion")
     implementation("org.bouncycastle:bcprov-jdk18on:$bcprovVersion")
     implementation("com.mortennobel:java-image-scaling:$javaImageScalingVersion")
     implementation("com.google.firebase:firebase-admin:$firebaseVersion")

--- a/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
@@ -196,7 +196,7 @@ class AttachmentService : AbstractService<Attachment, AttachmentRepository>() {
                 }
 
                 val resized = ImageIO.read(ByteArrayInputStream(bytes)).resize(attachment.type!!.width, attachment.type!!.height)
-                val webp = FileManager.encodeToWebP(ByteArrayOutputStream().apply { ImageIO.write(resized, "png", this) }.toByteArray())
+                val webp = FileManager.convertToWebP(ByteArrayOutputStream().apply { ImageIO.write(resized, "png", this) }.toByteArray())
 
                 if (webp.isEmpty()) {
                     logger.warning(FAILED_TO_ENCODE_MESSAGE)

--- a/src/main/kotlin/fr/shikkanime/utils/FileManager.kt
+++ b/src/main/kotlin/fr/shikkanime/utils/FileManager.kt
@@ -1,30 +1,82 @@
 package fr.shikkanime.utils
 
-import nu.pattern.OpenCV
-import org.opencv.core.MatOfByte
-import org.opencv.core.MatOfInt
-import org.opencv.imgcodecs.Imgcodecs
 import java.io.BufferedInputStream
 import java.io.File
-import java.io.FileInputStream
-import java.io.ObjectInputStream
-import kotlin.reflect.full.starProjectedType
-import kotlin.reflect.typeOf
+import java.util.concurrent.TimeUnit
+import java.util.logging.Level
+import java.util.logging.Logger
 
 object FileManager {
-    init {
-        OpenCV.loadLocally()
+    private const val WEBP_QUALITY = 75
+    private const val MAX_PROCESS_TIME = 30L
+    private val logger = Logger.getLogger(FileManager::class.java.name)
+
+    private fun isWebPAvailable(): Boolean {
+        return try {
+            val process = ProcessBuilder("cwebp", "-version").start()
+            val completed = process.waitFor(MAX_PROCESS_TIME, TimeUnit.SECONDS)
+
+            if (!completed) {
+                process.destroyForcibly()
+                false
+            } else {
+                process.exitValue() == 0
+            }
+        } catch (_: Exception) {
+            false
+        }
     }
 
-    fun encodeToWebP(image: ByteArray): ByteArray {
-        val matImage = Imgcodecs.imdecode(MatOfByte(*image), Imgcodecs.IMREAD_UNCHANGED)
-        val parameters = MatOfInt(Imgcodecs.IMWRITE_WEBP_QUALITY, 75)
-        val output = MatOfByte()
+    fun convertToWebP(image: ByteArray): ByteArray {
+        if (!isWebPAvailable()) {
+            throw Exception("cwebp command not found or not available")
+        }
 
-        if (Imgcodecs.imencode(".webp", matImage, output, parameters)) {
-            return output.toArray()
-        } else {
-            throw Exception("Failed to encode image to WebP")
+        // Create a temporary file for the input image
+        val tempInputFile = File.createTempFile("input_", ".png")
+        val tempOutputFile = File.createTempFile("output_", ".webp")
+        
+        try {
+            // Write input image to temporary file
+            tempInputFile.writeBytes(image)
+            
+            // Build the command to convert image using cwebp
+            val processBuilder = ProcessBuilder(
+                "cwebp",
+                "-q", "$WEBP_QUALITY",
+                tempInputFile.absolutePath,
+                "-o", tempOutputFile.absolutePath
+            )
+            
+            // Start the process
+            val process = processBuilder.start()
+            
+            // Wait for the process to complete with a timeout
+            val completed = process.waitFor(MAX_PROCESS_TIME, TimeUnit.SECONDS)
+            
+            if (!completed) {
+                process.destroyForcibly()
+                throw Exception("Image conversion timed out")
+            }
+            
+            if (process.exitValue() != 0) {
+                val error = process.errorStream.bufferedReader().readText()
+                throw Exception("Image conversion failed: $error")
+            }
+            
+            // Read the converted image
+            return tempOutputFile.readBytes()
+            
+        } catch (e: Exception) {
+            logger.log(Level.SEVERE, "Failed to convert image to WebP", e)
+            throw e
+        } finally {
+            // Clean up temporary files
+            if (!tempInputFile.delete())
+                logger.warning("Failed to delete temporary input file: ${tempInputFile.absolutePath}")
+
+            if(!tempOutputFile.delete())
+                logger.warning("Failed to delete temporary output file: ${tempOutputFile.absolutePath}")
         }
     }
 
@@ -36,15 +88,5 @@ object FileManager {
             e.printStackTrace()
             throw Exception("Failed to get input stream from resource")
         }
-    }
-
-    inline fun <reified T> readFile(file: File): T {
-        val value = ObjectInputStream(FileInputStream(file)).use { it.readObject() }
-
-        require(value is T && (T::class != List::class || typeOf<T>().arguments[0].type == (value as List<*>).firstOrNull()?.let { it::class.starProjectedType })) {
-            "Invalid type"
-        }
-
-        return value
     }
 }


### PR DESCRIPTION
This commit removes OpenCV dependency and replaces its WebP encoding functionality with a `cwebp` CLI-based implementation, simplifying the image conversion process. This improves maintainability by eliminating unnecessary complexity and reducing dependency footprint, while maintaining equivalent functionality.