### PR TITLE
Refactor episode ID handling to support multiple old IDs.

### DIFF
--- a/src/main/kotlin/fr/shikkanime/controllers/api/AnimeController.kt
+++ b/src/main/kotlin/fr/shikkanime/controllers/api/AnimeController.kt
@@ -16,11 +16,8 @@ import java.util.*
 
 @Controller("/api/v1/animes")
 class AnimeController : HasPageableRoute() {
-    @Inject
-    private lateinit var animeCacheService: AnimeCacheService
-
-    @Inject
-    private lateinit var memberFollowAnimeCacheService: MemberFollowAnimeCacheService
+    @Inject private lateinit var animeCacheService: AnimeCacheService
+    @Inject private lateinit var memberFollowAnimeCacheService: MemberFollowAnimeCacheService
 
     @Path
     @Get

--- a/src/main/kotlin/fr/shikkanime/factories/impl/AnimeFactory.kt
+++ b/src/main/kotlin/fr/shikkanime/factories/impl/AnimeFactory.kt
@@ -14,17 +14,10 @@ import fr.shikkanime.utils.withUTCString
 import org.hibernate.Hibernate
 
 class AnimeFactory : IGenericFactory<Anime, AnimeDto> {
-    @Inject
-    private lateinit var animeCacheService: AnimeCacheService
-
-    @Inject
-    private lateinit var animePlatformCacheService: AnimePlatformCacheService
-
-    @Inject
-    private lateinit var simulcastFactory: SimulcastFactory
-
-    @Inject
-    private lateinit var animePlatformFactory: AnimePlatformFactory
+    @Inject private lateinit var animeCacheService: AnimeCacheService
+    @Inject private lateinit var animePlatformCacheService: AnimePlatformCacheService
+    @Inject private lateinit var simulcastFactory: SimulcastFactory
+    @Inject private lateinit var animePlatformFactory: AnimePlatformFactory
 
     override fun toDto(entity: Anime): AnimeDto {
         val audioLocales = animeCacheService.getAudioLocales(entity) ?: emptySet()

--- a/src/main/kotlin/fr/shikkanime/factories/impl/EpisodeMappingFactory.kt
+++ b/src/main/kotlin/fr/shikkanime/factories/impl/EpisodeMappingFactory.kt
@@ -9,17 +9,10 @@ import fr.shikkanime.services.caches.EpisodeVariantCacheService
 import fr.shikkanime.utils.withUTCString
 
 class EpisodeMappingFactory : IEpisodeMappingFactory {
-    @Inject
-    private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
-
-    @Inject
-    private lateinit var episodeVariantFactory: EpisodeVariantFactory
-
-    @Inject
-    private lateinit var platformFactory: PlatformFactory
-
-    @Inject
-    private lateinit var animeFactory: AnimeFactory
+    @Inject private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
+    @Inject private lateinit var episodeVariantFactory: EpisodeVariantFactory
+    @Inject private lateinit var platformFactory: PlatformFactory
+    @Inject private lateinit var animeFactory: AnimeFactory
 
     override fun toDto(
         entity: EpisodeMapping,

--- a/src/main/kotlin/fr/shikkanime/factories/impl/GroupedEpisodeFactory.kt
+++ b/src/main/kotlin/fr/shikkanime/factories/impl/GroupedEpisodeFactory.kt
@@ -9,11 +9,8 @@ import fr.shikkanime.utils.Constant
 import fr.shikkanime.utils.withUTCString
 
 class GroupedEpisodeFactory : IGenericFactory<GroupedEpisode, GroupedEpisodeDto> {
-    @Inject
-    private lateinit var animeFactory: AnimeFactory
-
-    @Inject
-    private lateinit var platformFactory: PlatformFactory
+    @Inject private lateinit var animeFactory: AnimeFactory
+    @Inject private lateinit var platformFactory: PlatformFactory
 
     override fun toDto(entity: GroupedEpisode): GroupedEpisodeDto {
         val season = if (entity.minSeason == entity.maxSeason) entity.minSeason.toString() else "${entity.minSeason} - ${entity.maxSeason}"

--- a/src/main/kotlin/fr/shikkanime/factories/impl/MemberFactory.kt
+++ b/src/main/kotlin/fr/shikkanime/factories/impl/MemberFactory.kt
@@ -12,14 +12,9 @@ import fr.shikkanime.services.MemberFollowEpisodeService
 import fr.shikkanime.utils.withUTCString
 
 class MemberFactory : IGenericFactory<Member, MemberDto> {
-    @Inject
-    private lateinit var memberFollowAnimeService: MemberFollowAnimeService
-
-    @Inject
-    private lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
-
-    @Inject
-    private lateinit var attachmentService: AttachmentService
+    @Inject private lateinit var memberFollowAnimeService: MemberFollowAnimeService
+    @Inject private lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
+    @Inject private lateinit var attachmentService: AttachmentService
 
     override fun toDto(entity: Member): MemberDto {
         val seenAndUnseenDuration = memberFollowEpisodeService.getSeenAndUnseenDuration(entity)

--- a/src/main/kotlin/fr/shikkanime/jobs/DeleteOldMetricsJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/DeleteOldMetricsJob.kt
@@ -5,8 +5,7 @@ import fr.shikkanime.services.MetricService
 import java.time.ZonedDateTime
 
 class DeleteOldMetricsJob : AbstractJob {
-    @Inject
-    private lateinit var metricService: MetricService
+    @Inject private lateinit var metricService: MetricService
 
     override fun run() {
         val date = ZonedDateTime.now().minusWeeks(1)

--- a/src/main/kotlin/fr/shikkanime/jobs/FetchEpisodesJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/FetchEpisodesJob.kt
@@ -31,17 +31,10 @@ class FetchEpisodesJob : AbstractJob {
 
     private val typeIdentifiers = mutableSetOf<String>()
 
-    @Inject
-    private lateinit var episodeVariantService: EpisodeVariantService
-
-    @Inject
-    private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
-
-    @Inject
-    private lateinit var configCacheService: ConfigCacheService
-
-    @Inject
-    private lateinit var mailService: MailService
+    @Inject private lateinit var episodeVariantService: EpisodeVariantService
+    @Inject private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
+    @Inject private lateinit var configCacheService: ConfigCacheService
+    @Inject private lateinit var mailService: MailService
 
     override fun run() {
         if (isRunning) {

--- a/src/main/kotlin/fr/shikkanime/jobs/FetchOldEpisodesJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/FetchOldEpisodesJob.kt
@@ -25,32 +25,15 @@ import kotlin.streams.asSequence
 class FetchOldEpisodesJob : AbstractJob {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Inject
-    private lateinit var animationDigitalNetworkPlatform: AnimationDigitalNetworkPlatform
-
-    @Inject
-    private lateinit var crunchyrollPlatform: CrunchyrollPlatform
-
-    @Inject
-    private lateinit var animeService: AnimeService
-
-    @Inject
-    private lateinit var episodeVariantService: EpisodeVariantService
-
-    @Inject
-    private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
-
-    @Inject
-    private lateinit var configService: ConfigService
-
-    @Inject
-    private lateinit var configCacheService: ConfigCacheService
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
-
-    @Inject
-    private lateinit var mailService: MailService
+    @Inject private lateinit var animationDigitalNetworkPlatform: AnimationDigitalNetworkPlatform
+    @Inject private lateinit var crunchyrollPlatform: CrunchyrollPlatform
+    @Inject private lateinit var animeService: AnimeService
+    @Inject private lateinit var episodeVariantService: EpisodeVariantService
+    @Inject private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
+    @Inject private lateinit var configService: ConfigService
+    @Inject private lateinit var configCacheService: ConfigCacheService
+    @Inject private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var mailService: MailService
 
     private fun log(stringBuilder: StringBuilder, level: Level, message: String) {
         logger.log(level, message)

--- a/src/main/kotlin/fr/shikkanime/jobs/MetricJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/MetricJob.kt
@@ -8,8 +8,7 @@ import javax.management.Attribute
 import javax.management.ObjectName
 
 class MetricJob : AbstractJob {
-    @Inject
-    private lateinit var metricService: MetricService
+    @Inject private lateinit var metricService: MetricService
 
     override fun run() {
         metricService.save(

--- a/src/main/kotlin/fr/shikkanime/jobs/SendMailJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/SendMailJob.kt
@@ -14,11 +14,8 @@ import java.time.ZonedDateTime
 class SendMailJob : AbstractJob {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Inject
-    private lateinit var mailService: MailService
-
-    @Inject
-    private lateinit var configCacheService: ConfigCacheService
+    @Inject private lateinit var mailService: MailService
+    @Inject private lateinit var configCacheService: ConfigCacheService
 
     override fun run() {
         val mails = mailService.findAllNotSent()

--- a/src/main/kotlin/fr/shikkanime/jobs/UpdateAnimeJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/UpdateAnimeJob.kt
@@ -29,23 +29,12 @@ class UpdateAnimeJob : AbstractJob {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Inject
-    private lateinit var animeService: AnimeService
-
-    @Inject
-    private lateinit var animePlatformService: AnimePlatformService
-
-    @Inject
-    private lateinit var crunchyrollPlatform: CrunchyrollPlatform
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
-
-    @Inject
-    private lateinit var configCacheService: ConfigCacheService
-
-    @Inject
-    private lateinit var attachmentService: AttachmentService
+    @Inject private lateinit var animeService: AnimeService
+    @Inject private lateinit var animePlatformService: AnimePlatformService
+    @Inject private lateinit var crunchyrollPlatform: CrunchyrollPlatform
+    @Inject private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var configCacheService: ConfigCacheService
+    @Inject private lateinit var attachmentService: AttachmentService
 
     override fun run() {
         val zonedDateTime = ZonedDateTime.now().withSecond(0).withNano(0).withUTC()

--- a/src/main/kotlin/fr/shikkanime/jobs/UpdateAttachmentJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/UpdateAttachmentJob.kt
@@ -13,11 +13,8 @@ import java.time.ZonedDateTime
 class UpdateAttachmentJob : AbstractJob {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Inject
-    private lateinit var configCacheService: ConfigCacheService
-
-    @Inject
-    private lateinit var attachmentService: AttachmentService
+    @Inject private lateinit var configCacheService: ConfigCacheService
+    @Inject private lateinit var attachmentService: AttachmentService
 
     override fun run() {
         val zonedDateTime = ZonedDateTime.now().withSecond(0).withNano(0).withUTC()

--- a/src/main/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJob.kt
@@ -499,7 +499,7 @@ class UpdateEpisodeMappingJob : AbstractJob {
             val id = StringUtils.getVideoOldIdOrId(episodeVariant.identifier!!) ?: return
             val ids = animePlatformService.findAllIdByAnimeAndPlatform(episodeMapping.anime!!, episodeVariant.platform!!)
             val platformEpisodes = ids.flatMap { PrimeVideoCachedWrapper.getEpisodesByShowId(countryCode.locale, it) }
-            val episode = platformEpisodes.find { it.id == id || it.oldId == id } ?: return
+            val episode = platformEpisodes.find { it.id == id || it.oldIds.contains(id) } ?: return
 
             updateIdentifier(episodeVariant, id, episode.id, identifiers)
             updateUrl(episodeVariant, episode.url)

--- a/src/main/kotlin/fr/shikkanime/services/AnimeService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AnimeService.kt
@@ -33,41 +33,18 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 class AnimeService : AbstractService<Anime, AnimeRepository>() {
-    @Inject
-    private lateinit var animeRepository: AnimeRepository
-
-    @Inject
-    private lateinit var simulcastService: SimulcastService
-
-    @Inject
-    private lateinit var episodeMappingService: EpisodeMappingService
-
-    @Inject
-    private lateinit var episodeVariantService: EpisodeVariantService
-
-    @Inject
-    private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
-
-    @Inject
-    private lateinit var memberFollowAnimeService: MemberFollowAnimeService
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
-
-    @Inject
-    private lateinit var animePlatformService: AnimePlatformService
-
-    @Inject
-    private lateinit var animeFactory: AnimeFactory
-
-    @Inject
-    private lateinit var platformFactory: PlatformFactory
-
-    @Inject
-    private lateinit var episodeMappingFactory: EpisodeMappingFactory
-
-    @Inject
-    private lateinit var attachmentService: AttachmentService
+    @Inject private lateinit var animeRepository: AnimeRepository
+    @Inject private lateinit var simulcastService: SimulcastService
+    @Inject private lateinit var episodeMappingService: EpisodeMappingService
+    @Inject private lateinit var episodeVariantService: EpisodeVariantService
+    @Inject private lateinit var episodeVariantCacheService: EpisodeVariantCacheService
+    @Inject private lateinit var memberFollowAnimeService: MemberFollowAnimeService
+    @Inject private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var animePlatformService: AnimePlatformService
+    @Inject private lateinit var animeFactory: AnimeFactory
+    @Inject private lateinit var platformFactory: PlatformFactory
+    @Inject private lateinit var episodeMappingFactory: EpisodeMappingFactory
+    @Inject private lateinit var attachmentService: AttachmentService
 
     override fun getRepository() = animeRepository
 

--- a/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
@@ -31,20 +31,11 @@ class AttachmentService : AbstractService<Attachment, AttachmentRepository>() {
     private val imageCache = LRUCache<UUID, ByteArray>(100)
     val inProgressAttachments: MutableSet<UUID> = Collections.synchronizedSet(HashSet<UUID>())
 
-    @Inject
-    private lateinit var attachmentRepository: AttachmentRepository
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
-
-    @Inject
-    private lateinit var animeService: AnimeService
-
-    @Inject
-    private lateinit var episodeMappingService: EpisodeMappingService
-
-    @Inject
-    private lateinit var memberService: MemberService
+    @Inject private lateinit var attachmentRepository: AttachmentRepository
+    @Inject private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var animeService: AnimeService
+    @Inject private lateinit var episodeMappingService: EpisodeMappingService
+    @Inject private lateinit var memberService: MemberService
 
     override fun getRepository() = attachmentRepository
 

--- a/src/main/kotlin/fr/shikkanime/services/ConfigService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/ConfigService.kt
@@ -8,11 +8,8 @@ import fr.shikkanime.repositories.ConfigRepository
 import java.util.*
 
 class ConfigService : AbstractService<Config, ConfigRepository>() {
-    @Inject
-    private lateinit var configRepository: ConfigRepository
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var configRepository: ConfigRepository
+    @Inject private lateinit var traceActionService: TraceActionService
 
     override fun getRepository() = configRepository
 

--- a/src/main/kotlin/fr/shikkanime/services/MemberFollowAnimeService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MemberFollowAnimeService.kt
@@ -13,17 +13,10 @@ import fr.shikkanime.utils.routes.Response
 import java.util.*
 
 class MemberFollowAnimeService : AbstractService<MemberFollowAnime, MemberFollowAnimeRepository>() {
-    @Inject
-    private lateinit var memberFollowAnimeRepository: MemberFollowAnimeRepository
-
-    @Inject
-    private lateinit var memberCacheService: MemberCacheService
-
-    @Inject
-    private lateinit var animeService: AnimeService
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var memberFollowAnimeRepository: MemberFollowAnimeRepository
+    @Inject private lateinit var memberCacheService: MemberCacheService
+    @Inject private lateinit var animeService: AnimeService
+    @Inject private lateinit var traceActionService: TraceActionService
 
     override fun getRepository() = memberFollowAnimeRepository
 

--- a/src/main/kotlin/fr/shikkanime/services/MemberService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MemberService.kt
@@ -25,20 +25,11 @@ import javax.imageio.ImageIO
 class MemberService : AbstractService<Member, MemberRepository>() {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Inject
-    private lateinit var memberRepository: MemberRepository
-
-    @Inject
-    private lateinit var memberActionService: MemberActionService
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
-
-    @Inject
-    private lateinit var memberFactory: MemberFactory
-
-    @Inject
-    private lateinit var attachmentService: AttachmentService
+    @Inject private lateinit var memberRepository: MemberRepository
+    @Inject private lateinit var memberActionService: MemberActionService
+    @Inject private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var memberFactory: MemberFactory
+    @Inject private lateinit var attachmentService: AttachmentService
 
     override fun getRepository() = memberRepository
 

--- a/src/main/kotlin/fr/shikkanime/services/MetricService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MetricService.kt
@@ -6,8 +6,7 @@ import fr.shikkanime.repositories.MetricRepository
 import java.time.ZonedDateTime
 
 class MetricService : AbstractService<Metric, MetricRepository>() {
-    @Inject
-    private lateinit var metricRepository: MetricRepository
+    @Inject private lateinit var metricRepository: MetricRepository
 
     override fun getRepository() = metricRepository
 

--- a/src/main/kotlin/fr/shikkanime/services/SimulcastService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/SimulcastService.kt
@@ -11,14 +11,9 @@ import fr.shikkanime.utils.withUTCString
 import java.time.ZonedDateTime
 
 class SimulcastService : AbstractService<Simulcast, SimulcastRepository>() {
-    @Inject
-    private lateinit var simulcastRepository: SimulcastRepository
-
-    @Inject
-    private lateinit var traceActionService: TraceActionService
-
-    @Inject
-    private lateinit var simulcastFactory: SimulcastFactory
+    @Inject private lateinit var simulcastRepository: SimulcastRepository
+    @Inject private lateinit var traceActionService: TraceActionService
+    @Inject private lateinit var simulcastFactory: SimulcastFactory
 
     override fun getRepository() = simulcastRepository
 

--- a/src/main/kotlin/fr/shikkanime/services/caches/AttachmentCacheService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/caches/AttachmentCacheService.kt
@@ -8,8 +8,7 @@ import fr.shikkanime.utils.MapCache
 import java.util.*
 
 class AttachmentCacheService : ICacheService {
-    @Inject
-    private lateinit var attachmentService: AttachmentService
+    @Inject private lateinit var attachmentService: AttachmentService
 
     fun findByEntityUuidTypeAndActive(uuid: UUID, type: ImageType) = MapCache.getOrComputeNullable(
         "AttachmentCacheService.findByEntityUuidTypeAndActive",

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractPrimeVideoWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractPrimeVideoWrapper.kt
@@ -19,7 +19,7 @@ abstract class AbstractPrimeVideoWrapper {
 
     data class Episode(
         val show: Show,
-        val oldId: String,
+        val oldIds: Set<String>,
         val id: String,
         val season: Int,
         val number: Int,

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/PrimeVideoWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/PrimeVideoWrapper.kt
@@ -72,15 +72,17 @@ object PrimeVideoWrapper : AbstractPrimeVideoWrapper(){
         show: Show,
         btfState: JsonObject
     ): Episode {
-        val episodeId = btfState.getAsJsonObject("self").getAsJsonObject(key).getAsString("compactGTI")!!
         val episodeNumber = episodeJson.getAsInt("episodeNumber")!!
         val audioTracks = episodeJson.getAsJsonArray("audioTracks")?.map { it.asString }?.toSet() ?: emptySet()
         val subtitles = episodeJson.getAsJsonArray("subtitles")?.map { it.asString }?.toSet() ?: emptySet()
 
         return Episode(
             show,
-            EncryptionManager.toSHA512("${show.id}-${season.number}-$episodeNumber").substring(0..<8),
-            episodeId,
+            setOf(
+                EncryptionManager.toSHA512("${show.id}-${season.number}-$episodeNumber").substring(0..<8),
+                btfState.getAsJsonObject("self").getAsJsonObject(key).getAsString("compactGTI")!!
+            ),
+            key.substringAfterLast("."),
             season.number,
             episodeNumber,
             episodeJson.getAsString("title")!!,

--- a/src/test/kotlin/fr/shikkanime/AbstractTest.kt
+++ b/src/test/kotlin/fr/shikkanime/AbstractTest.kt
@@ -12,44 +12,19 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 
 abstract class AbstractTest {
-    @Inject
-    protected lateinit var animeService: AnimeService
-
-    @Inject
-    protected lateinit var episodeMappingService: EpisodeMappingService
-
-    @Inject
-    protected lateinit var episodeVariantService: EpisodeVariantService
-
-    @Inject
-    protected lateinit var memberService: MemberService
-
-    @Inject
-    protected lateinit var memberActionService: MemberActionService
-
-    @Inject
-    protected lateinit var memberFollowAnimeService: MemberFollowAnimeService
-
-    @Inject
-    protected lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
-
-    @Inject
-    protected lateinit var animePlatformService: AnimePlatformService
-
-    @Inject
-    protected lateinit var configService: ConfigService
-
-    @Inject
-    protected lateinit var traceActionService: TraceActionService
-
-    @Inject
-    protected lateinit var ruleService: RuleService
-
-    @Inject
-    protected lateinit var attachmentService: AttachmentService
-
-    @Inject
-    private lateinit var database: Database
+    @Inject protected lateinit var animeService: AnimeService
+    @Inject protected lateinit var episodeMappingService: EpisodeMappingService
+    @Inject protected lateinit var episodeVariantService: EpisodeVariantService
+    @Inject protected lateinit var memberService: MemberService
+    @Inject protected lateinit var memberActionService: MemberActionService
+    @Inject protected lateinit var memberFollowAnimeService: MemberFollowAnimeService
+    @Inject protected lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
+    @Inject protected lateinit var animePlatformService: AnimePlatformService
+    @Inject protected lateinit var configService: ConfigService
+    @Inject protected lateinit var traceActionService: TraceActionService
+    @Inject protected lateinit var ruleService: RuleService
+    @Inject protected lateinit var attachmentService: AttachmentService
+    @Inject private lateinit var database: Database
 
     @BeforeEach
     open fun setUp() {

--- a/src/test/kotlin/fr/shikkanime/jobs/FetchOldEpisodesJobTest.kt
+++ b/src/test/kotlin/fr/shikkanime/jobs/FetchOldEpisodesJobTest.kt
@@ -12,11 +12,8 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 
 class FetchOldEpisodesJobTest : AbstractTest() {
-    @Inject
-    private lateinit var fetchOldEpisodesJob: FetchOldEpisodesJob
-
-    @Inject
-    private lateinit var crunchyrollPlatform: CrunchyrollPlatform
+    @Inject private lateinit var fetchOldEpisodesJob: FetchOldEpisodesJob
+    @Inject private lateinit var crunchyrollPlatform: CrunchyrollPlatform
 
     @Test
     fun `fix issue #503`() {

--- a/src/test/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJobTest.kt
+++ b/src/test/kotlin/fr/shikkanime/jobs/UpdateEpisodeMappingJobTest.kt
@@ -16,8 +16,7 @@ import java.time.ZonedDateTime
 import java.util.stream.Stream
 
 class UpdateEpisodeMappingJobTest : AbstractTest() {
-    @Inject
-    private lateinit var updateEpisodeMappingJob: UpdateEpisodeMappingJob
+    @Inject private lateinit var updateEpisodeMappingJob: UpdateEpisodeMappingJob
 
     @BeforeEach
     override fun setUp() {

--- a/src/test/kotlin/fr/shikkanime/platforms/AnimationDigitalNetworkPlatformTest.kt
+++ b/src/test/kotlin/fr/shikkanime/platforms/AnimationDigitalNetworkPlatformTest.kt
@@ -16,8 +16,7 @@ import java.io.File
 import java.time.ZonedDateTime
 
 class AnimationDigitalNetworkPlatformTest : AbstractTest() {
-    @Inject
-    lateinit var platform: AnimationDigitalNetworkPlatform
+    @Inject lateinit var platform: AnimationDigitalNetworkPlatform
 
     @BeforeEach
     override fun setUp() {

--- a/src/test/kotlin/fr/shikkanime/platforms/CrunchyrollPlatformTest.kt
+++ b/src/test/kotlin/fr/shikkanime/platforms/CrunchyrollPlatformTest.kt
@@ -25,8 +25,7 @@ import java.time.ZonedDateTime
 import java.util.stream.Stream
 
 class CrunchyrollPlatformTest : AbstractTest() {
-    @Inject
-    lateinit var platform: CrunchyrollPlatform
+    @Inject lateinit var platform: CrunchyrollPlatform
 
     @BeforeEach
     override fun setUp() {

--- a/src/test/kotlin/fr/shikkanime/platforms/NetflixPlatformTest.kt
+++ b/src/test/kotlin/fr/shikkanime/platforms/NetflixPlatformTest.kt
@@ -14,8 +14,7 @@ import java.time.ZonedDateTime
 import java.util.stream.Stream
 
 class NetflixPlatformTest : AbstractTest() {
-    @Inject
-    private lateinit var netflixPlatform: NetflixPlatform
+    @Inject private lateinit var netflixPlatform: NetflixPlatform
 
     data class NetflixTestCase(
         val netflixId: String,

--- a/src/test/kotlin/fr/shikkanime/platforms/PrimeVideoPlatformTest.kt
+++ b/src/test/kotlin/fr/shikkanime/platforms/PrimeVideoPlatformTest.kt
@@ -15,8 +15,7 @@ import java.time.ZonedDateTime
 import java.util.stream.Stream
 
 class PrimeVideoPlatformTest : AbstractTest() {
-    @Inject
-    private lateinit var primeVideoPlatform: PrimeVideoPlatform
+    @Inject private lateinit var primeVideoPlatform: PrimeVideoPlatform
 
     data class SimulcastTestCase(
         val simulcastName: String,

--- a/src/test/kotlin/fr/shikkanime/services/AnimeServiceTest.kt
+++ b/src/test/kotlin/fr/shikkanime/services/AnimeServiceTest.kt
@@ -20,8 +20,7 @@ import java.time.ZonedDateTime
 import kotlin.test.assertTrue
 
 class AnimeServiceTest : AbstractTest() {
-    @Inject
-    private lateinit var animeFactory: AnimeFactory
+    @Inject private lateinit var animeFactory: AnimeFactory
 
     @Test
     fun `update with no episodes`() {

--- a/src/test/kotlin/fr/shikkanime/services/caches/BotDetectorCacheTest.kt
+++ b/src/test/kotlin/fr/shikkanime/services/caches/BotDetectorCacheTest.kt
@@ -7,8 +7,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class BotDetectorCacheTest : AbstractTest() {
-    @Inject
-    private lateinit var botDetectorCache: BotDetectorCache
+    @Inject private lateinit var botDetectorCache: BotDetectorCache
 
     @Test
     fun testBotDetectorCache() {


### PR DESCRIPTION
Updated `Episode` to store a set of old IDs instead of a single value, enabling better tracking of legacy identifiers. Adjusted related logic in `PrimeVideoWrapper` and `UpdateEpisodeMappingJob` to accommodate the changes.