### PR TITLE
Implement Tiered Anime Update Scheduling

### DIFF
--- a/src/main/kotlin/fr/shikkanime/entities/enums/ConfigPropertyKey.kt
+++ b/src/main/kotlin/fr/shikkanime/entities/enums/ConfigPropertyKey.kt
@@ -41,7 +41,6 @@ enum class ConfigPropertyKey(val key: String) {
     TWITTER_CONSUMER_SECRET("twitter_consumer_secret"),
     TWITTER_FIRST_MESSAGE("twitter_first_message"),
     TWITTER_SECOND_MESSAGE("twitter_second_message"),
-    UPDATE_ANIME_DELAY("update_anime_delay"),
     UPDATE_ANIME_SIZE("update_anime_size"),
     UPDATE_EPISODE_DELAY("update_episode_delay"),
     UPDATE_EPISODE_SIZE("update_episode_size"),
@@ -59,4 +58,7 @@ enum class ConfigPropertyKey(val key: String) {
     TWITTER_ENABLED("twitter_enabled"),
     NETFLIX_ID("netflix_id"),
     NETFLIX_SECURE_ID("netflix_secure_id"),
+    UPDATE_ANIME_DELAY_CURRENT_SEASON("update_anime_delay_current_season"),
+    UPDATE_ANIME_DELAY_LAST_SEASON("update_anime_delay_last_season"),
+    UPDATE_ANIME_DELAY_OTHERS("update_anime_delay_others"),
 }

--- a/src/main/kotlin/fr/shikkanime/entities/enums/ImageType.kt
+++ b/src/main/kotlin/fr/shikkanime/entities/enums/ImageType.kt
@@ -3,6 +3,6 @@ package fr.shikkanime.entities.enums
 enum class ImageType(val width: Int, val height: Int) {
     THUMBNAIL(1560, 2340),
     BANNER(1920, 1080),
-    CAROUSEL(1920, 1080),
+    CAROUSEL(1920, -1),
     MEMBER_PROFILE(128, 128),
 }

--- a/src/main/kotlin/fr/shikkanime/jobs/UpdateAnimeJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/UpdateAnimeJob.kt
@@ -39,8 +39,7 @@ class UpdateAnimeJob : AbstractJob {
 
     override fun run() {
         val zonedDateTime = ZonedDateTime.now().withSecond(0).withNano(0).withUTC()
-        val lastDateTime = zonedDateTime.minusDays(configCacheService.getValueAsInt(ConfigPropertyKey.UPDATE_ANIME_DELAY, 30).toLong())
-        val animes = animeService.findAllNeedUpdate(lastDateTime)
+        val animes = animeService.findAllNeedUpdate()
         logger.info("Found ${animes.size} animes to update")
 
         val needUpdateAnimes = animes.shuffled()

--- a/src/main/resources/db/changelog/2025/10/01-changelog.xml
+++ b/src/main/resources/db/changelog/2025/10/01-changelog.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <property global="false" name="id" value="1760605872086"/>
+    <property global="false" name="author" value="Ziedelth"/>
+
+    <changeSet id="${id}-1" author="${author}" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*)
+                                         FROM config
+                                         WHERE property_key = 'update_anime_delay_current_season'</sqlCheck>
+        </preConditions>
+
+        <insert tableName="config">
+            <column name="uuid" valueComputed="gen_random_uuid()"/>
+            <column name="property_key" value="update_anime_delay_current_season"/>
+            <column name="property_value" value="7"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="${id}-2" author="${author}" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*)
+                                         FROM config
+                                         WHERE property_key = 'update_anime_delay_last_season'</sqlCheck>
+        </preConditions>
+
+        <insert tableName="config">
+            <column name="uuid" valueComputed="gen_random_uuid()"/>
+            <column name="property_key" value="update_anime_delay_last_season"/>
+            <column name="property_value" value="30"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="${id}-3" author="${author}" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*)
+                                         FROM config
+                                         WHERE property_key = 'update_anime_delay_others'</sqlCheck>
+        </preConditions>
+
+        <insert tableName="config">
+            <column name="uuid" valueComputed="gen_random_uuid()"/>
+            <column name="property_key" value="update_anime_delay_others"/>
+            <column name="property_value" value="90"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="${id}-4" author="${author}" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT COUNT(*)
+                                         FROM config
+                                         WHERE property_key = 'update_anime_delay'</sqlCheck>
+        </preConditions>
+
+        <delete tableName="config">
+            <where>property_key = 'update_anime_delay'</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -110,4 +110,6 @@
     <include file="/db/changelog/2025/09/01-changelog.xml"/>
     <include file="/db/changelog/2025/09/02-changelog.xml"/>
     <include file="/db/changelog/2025/09/03-changelog.xml"/>
+    <!-- October 2025 -->
+    <include file="/db/changelog/2025/10/01-changelog.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This pull request overhauls the anime update mechanism, replacing the single, fixed-interval schedule with a dynamic, tiered system based on the anime's broadcast season (simulcast). This change significantly improves the efficiency and relevance of the update process.
**Key Changes:**
- **Tiered Update Logic:** Animes are now categorized and updated based on their relevance:
  - **Current Season:** Updated every 7 days (configurable).
  - **Previous Season:** Updated every 30 days (configurable).
  - **Older Animes:** Updated every 90 days (configurable).
- **Performance Optimization:** The selection of animes to be updated is now handled by a single, performant database query using JPA's Criteria API. This avoids loading the entire list of animes into memory and ensures the filtering is done at the database level.
- **Configuration:** Introduced three new configuration keys to easily manage the update intervals without requiring code changes or a server restart:
  - `UPDATE_ANIME_DELAY_CURRENT_SEASON`
  - `UPDATE_ANIME_DELAY_LAST_SEASON`
  - `UPDATE_ANIME_DELAY_OTHERS`
- **Code Refactoring:** 
  - The core logic has been moved from `UpdateAnimeJob` to `AnimeService` and `AnimeRepository` for better separation of concerns.
  - `AnimeService` now leverages `SimulcastCacheService` to efficiently determine the current and last simulcasts.