### PR TITLE
feat: implement GDPR-compliant member deletion and enhance associated services

### DIFF
--- a/hibernate.cfg.xml
+++ b/hibernate.cfg.xml
@@ -17,6 +17,7 @@
         <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.region.factory_class">jcache</property>
         <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.jcache.cache_manager_uri">classpath:ehcache.xml</property>
         <property name="hibernate.javax.cache.missing_cache_strategy">create</property>
     </session-factory>
 </hibernate-configuration>

--- a/src/main/kotlin/fr/shikkanime/controllers/admin/api/MemberController.kt
+++ b/src/main/kotlin/fr/shikkanime/controllers/admin/api/MemberController.kt
@@ -139,4 +139,12 @@ class MemberController : HasPageableRoute() {
             )
         )
     }
+
+    @Path("/{memberUuid}")
+    @Delete
+    private fun deleteMember(@PathParam memberUuid: UUID): Response {
+        val member = memberService.find(memberUuid) ?: return Response.notFound()
+        memberService.delete(member)
+        return Response.noContent()
+    }
 }

--- a/src/main/kotlin/fr/shikkanime/controllers/api/MemberController.kt
+++ b/src/main/kotlin/fr/shikkanime/controllers/api/MemberController.kt
@@ -160,4 +160,13 @@ class MemberController : HasPageableRoute() {
         val (_, limit, _) = pageableRoute(null, limitParam, null, null)
         return Response.ok(memberCacheService.getRefreshMember(memberUuid, limit) ?: return Response.notFound())
     }
+
+    @Path
+    @Delete
+    @JWTAuthenticated
+    private fun deleteMember(@JWTUser memberUuid: UUID): Response {
+        val member = memberService.find(memberUuid) ?: return Response.notFound()
+        memberService.delete(member)
+        return Response.noContent()
+    }
 }

--- a/src/main/kotlin/fr/shikkanime/repositories/AbstractRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/AbstractRepository.kt
@@ -12,12 +12,15 @@ import jakarta.persistence.criteria.CriteriaQuery
 import org.hibernate.ScrollMode
 import org.hibernate.jpa.AvailableHints
 import org.hibernate.query.Query
+import java.lang.reflect.ParameterizedType
 import java.util.*
 
 abstract class AbstractRepository<E : ShikkEntity> {
     @Inject protected lateinit var database: Database
 
-    protected abstract fun getEntityClass(): Class<E>
+    @Suppress("UNCHECKED_CAST")
+    protected open fun getEntityClass() =
+        (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0] as Class<E>
 
     fun <T> createReadOnlyQuery(entityManager: EntityManager, query: CriteriaQuery<T>) = createReadOnlyQuery(entityManager.createQuery(query))
 

--- a/src/main/kotlin/fr/shikkanime/repositories/AttachmentRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/AttachmentRepository.kt
@@ -11,6 +11,21 @@ import java.util.*
 class AttachmentRepository : AbstractRepository<Attachment>() {
     override fun getEntityClass() = Attachment::class.java
 
+    fun findAllByEntityUuid(entityUuid: UUID): List<Attachment> {
+        return database.entityManager.use {
+            val cb = it.criteriaBuilder
+            val query = cb.createQuery(getEntityClass())
+            val root = query.from(getEntityClass())
+
+            query.where(
+                cb.equal(root[Attachment_.entityUuid], entityUuid)
+            )
+
+            createReadOnlyQuery(it, query)
+                .resultList
+        }
+    }
+
     fun findAllByEntityUuidAndType(entityUuid: UUID, type: ImageType): List<Attachment> {
         return database.entityManager.use {
             val cb = it.criteriaBuilder

--- a/src/main/kotlin/fr/shikkanime/repositories/MailRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/MailRepository.kt
@@ -6,6 +6,21 @@ import fr.shikkanime.entities.Mail_
 class MailRepository : AbstractRepository<Mail>() {
     override fun getEntityClass() = Mail::class.java
 
+    fun findAllByRecipient(recipient: String): List<Mail> {
+        return database.entityManager.use {
+            val cb = it.criteriaBuilder
+            val query = cb.createQuery(getEntityClass())
+            val root = query.from(getEntityClass())
+
+            query.where(
+                cb.equal(root[Mail_.recipient], recipient)
+            )
+
+            createReadOnlyQuery(it, query)
+                .resultList
+        }
+    }
+
     fun findAllNotSent(): List<Mail> {
         return database.entityManager.use {
             val cb = it.criteriaBuilder

--- a/src/main/kotlin/fr/shikkanime/repositories/MemberActionRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/MemberActionRepository.kt
@@ -2,12 +2,28 @@ package fr.shikkanime.repositories
 
 import fr.shikkanime.entities.MemberAction
 import fr.shikkanime.entities.MemberAction_
+import fr.shikkanime.entities.Member_
 import fr.shikkanime.services.MemberActionService
 import java.time.ZonedDateTime
 import java.util.*
 
 class MemberActionRepository : AbstractRepository<MemberAction>() {
     override fun getEntityClass() = MemberAction::class.java
+
+    fun findAllByMember(memberUuid: UUID): List<MemberAction> {
+        return database.entityManager.use {
+            val cb = it.criteriaBuilder
+            val query = cb.createQuery(getEntityClass())
+            val root = query.from(getEntityClass())
+
+            query.where(
+                cb.equal(root[MemberAction_.member][Member_.uuid], memberUuid)
+            )
+
+            createReadOnlyQuery(it, query)
+                .resultList
+        }
+    }
 
     fun findAllNotValidated(): List<MemberAction> {
         return database.entityManager.use {

--- a/src/main/kotlin/fr/shikkanime/repositories/MemberFollowAnimeRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/MemberFollowAnimeRepository.kt
@@ -10,6 +10,21 @@ import java.util.*
 class MemberFollowAnimeRepository : AbstractRepository<MemberFollowAnime>() {
     override fun getEntityClass() = MemberFollowAnime::class.java
 
+    fun findAllByMember(memberUuid: UUID): List<MemberFollowAnime> {
+        return database.entityManager.use {
+            val cb = it.criteriaBuilder
+            val query = cb.createQuery(getEntityClass())
+            val root = query.from(getEntityClass())
+
+            query.where(
+                cb.equal(root[MemberFollowAnime_.member][Member_.uuid], memberUuid)
+            )
+
+            createReadOnlyQuery(it, query)
+                .resultList
+        }
+    }
+
     fun findAllFollowedAnimes(memberUuid: UUID, page: Int, limit: Int): Pageable<Anime> {
         return database.entityManager.use {
             val cb = it.criteriaBuilder

--- a/src/main/kotlin/fr/shikkanime/repositories/MemberFollowEpisodeRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/MemberFollowEpisodeRepository.kt
@@ -9,6 +9,21 @@ import java.util.*
 class MemberFollowEpisodeRepository : AbstractRepository<MemberFollowEpisode>() {
     override fun getEntityClass() = MemberFollowEpisode::class.java
 
+    fun findAllByMember(memberUuid: UUID): List<MemberFollowEpisode> {
+        return database.entityManager.use {
+            val cb = it.criteriaBuilder
+            val query = cb.createQuery(getEntityClass())
+            val root = query.from(getEntityClass())
+
+            query.where(
+                cb.equal(root[MemberFollowEpisode_.member][Member_.uuid], memberUuid)
+            )
+
+            createReadOnlyQuery(it, query)
+                .resultList
+        }
+    }
+
     fun findAllFollowedEpisodes(memberUuid: UUID, page: Int, limit: Int): Pageable<EpisodeMapping> {
         return database.entityManager.use {
             val cb = it.criteriaBuilder

--- a/src/main/kotlin/fr/shikkanime/repositories/MemberRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/MemberRepository.kt
@@ -18,8 +18,6 @@ import java.time.ZonedDateTime
 import java.util.*
 
 class MemberRepository : AbstractRepository<Member>() {
-    override fun getEntityClass() = Member::class.java
-
     fun findAllByRoles(roles: List<Role>): List<Member> {
         return database.entityManager.use {
             val cb = it.criteriaBuilder

--- a/src/main/kotlin/fr/shikkanime/repositories/TraceActionRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/TraceActionRepository.kt
@@ -14,6 +14,21 @@ import java.util.*
 class TraceActionRepository : AbstractRepository<TraceAction>() {
     override fun getEntityClass() = TraceAction::class.java
 
+    fun findAllByEntityUuid(entityUuid: UUID): List<TraceAction> {
+        return database.entityManager.use {
+            val cb = it.criteriaBuilder
+            val query = cb.createQuery(getEntityClass())
+            val root = query.from(getEntityClass())
+
+            query.where(
+                cb.equal(root[TraceAction_.entityUuid], entityUuid)
+            )
+
+            createReadOnlyQuery(it, query)
+                .resultList
+        }
+    }
+
     fun findAllBy(entityType: String?, action: String?, page: Int, limit: Int): Pageable<TraceAction> {
         return database.entityManager.use {
             val cb = it.criteriaBuilder

--- a/src/main/kotlin/fr/shikkanime/services/AbstractService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AbstractService.kt
@@ -1,31 +1,33 @@
 package fr.shikkanime.services
 
+import com.google.inject.Inject
 import fr.shikkanime.entities.ShikkEntity
 import fr.shikkanime.repositories.AbstractRepository
 import java.util.*
 
 abstract class AbstractService<E : ShikkEntity, R : AbstractRepository<E>> {
-    protected abstract fun getRepository(): R
+    @Inject
+    protected lateinit var repository: R
 
-    open fun findAll() = getRepository().findAll()
+    open fun findAll() = repository.findAll()
 
-    fun findAllUuids() = getRepository().findAllUuids()
+    fun findAllUuids() = repository.findAllUuids()
 
-    fun findAllByUuids(uuids: Collection<UUID>) = getRepository().findAllByUuids(uuids)
+    fun findAllByUuids(uuids: Collection<UUID>) = repository.findAllByUuids(uuids)
 
-    fun getReference(uuid: UUID) = getRepository().getReference(uuid)
+    fun getReference(uuid: UUID) = repository.getReference(uuid)
 
-    fun find(uuid: UUID?) = if (uuid != null) getRepository().find(uuid) else null
+    fun find(uuid: UUID?) = if (uuid != null) repository.find(uuid) else null
 
-    open fun save(entity: E) = getRepository().save(entity)
+    open fun save(entity: E) = repository.save(entity)
 
-    open fun saveAll(entities: List<E>) = getRepository().saveAll(entities)
+    open fun saveAll(entities: List<E>) = repository.saveAll(entities)
 
-    open fun update(entity: E) = getRepository().update(entity)
+    open fun update(entity: E) = repository.update(entity)
 
-    fun updateAll(entities: List<E>) = getRepository().updateAll(entities)
+    fun updateAll(entities: List<E>) = repository.updateAll(entities)
 
-    open fun delete(entity: E) = getRepository().delete(entity)
+    open fun delete(entity: E) = repository.delete(entity)
 
-    open fun deleteAll(entities: List<E>) = getRepository().deleteAll(entities)
+    open fun deleteAll(entities: List<E>) = repository.deleteAll(entities)
 }

--- a/src/main/kotlin/fr/shikkanime/services/AnalyticsService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AnalyticsService.kt
@@ -1,26 +1,20 @@
 package fr.shikkanime.services
 
-import com.google.inject.Inject
 import fr.shikkanime.entities.EpisodeMapping
 import fr.shikkanime.entities.enums.CountryCode
 import fr.shikkanime.entities.enums.Season
 import fr.shikkanime.repositories.AnalyticsRepository
 
 class AnalyticsService : AbstractService<EpisodeMapping, AnalyticsRepository>() {
-    @Inject
-    private lateinit var analyticsRepository: AnalyticsRepository
-
-    override fun getRepository() = analyticsRepository
-
     fun getAllMarketShare(startYear: Int, endYear: Int) =
-        analyticsRepository.getAllMarketShare(startYear, endYear)
+        repository.getAllMarketShare(startYear, endYear)
             .sortedWith(compareBy({ it.simulcast.year }, { Season.entries.indexOf(it.simulcast.season) }))
 
     fun getSubCoverage(countryCode: CountryCode, startYear: Int, endYear: Int) =
-        analyticsRepository.getSubCoverage(countryCode, startYear, endYear)
+        repository.getSubCoverage(countryCode, startYear, endYear)
             .sortedWith(compareBy({ it.simulcast.year }, { Season.entries.indexOf(it.simulcast.season) }))
 
     fun getAllGenreCoverage(startYear: Int, endYear: Int) =
-        analyticsRepository.getAllGenreCoverage(startYear, endYear)
+        repository.getAllGenreCoverage(startYear, endYear)
             .sortedWith(compareBy({ it.simulcast.year }, { Season.entries.indexOf(it.simulcast.season) }))
 }

--- a/src/main/kotlin/fr/shikkanime/services/AnimePlatformService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AnimePlatformService.kt
@@ -1,6 +1,5 @@
 package fr.shikkanime.services
 
-import com.google.inject.Inject
 import fr.shikkanime.entities.Anime
 import fr.shikkanime.entities.AnimePlatform
 import fr.shikkanime.entities.enums.Platform
@@ -8,24 +7,20 @@ import fr.shikkanime.repositories.AnimePlatformRepository
 import java.util.*
 
 class AnimePlatformService : AbstractService<AnimePlatform, AnimePlatformRepository>() {
-    @Inject private lateinit var animePlatformRepository: AnimePlatformRepository
+    fun findAllByAnime(uuid: UUID) = repository.findAllByAnime(uuid)
 
-    override fun getRepository() = animePlatformRepository
+    fun findAllByAnime(anime: Anime) = repository.findAllByAnime(anime.uuid!!)
 
-    fun findAllByAnime(uuid: UUID) = animePlatformRepository.findAllByAnime(uuid)
-
-    fun findAllByAnime(anime: Anime) = animePlatformRepository.findAllByAnime(anime.uuid!!)
-
-    fun findAllByPlatform(platform: Platform) = animePlatformRepository.findAllByPlatform(platform)
+    fun findAllByPlatform(platform: Platform) = repository.findAllByPlatform(platform)
 
     fun findAllIdByAnimeAndPlatform(animeUuid: UUID, platform: Platform) =
-        animePlatformRepository.findAllIdByAnimeAndPlatform(animeUuid, platform)
+        repository.findAllIdByAnimeAndPlatform(animeUuid, platform)
 
     fun findAllIdByAnimeAndPlatform(anime: Anime, platform: Platform) =
         findAllIdByAnimeAndPlatform(anime.uuid!!, platform)
 
     fun findByAnimePlatformAndId(animeUuid: UUID, platform: Platform, platformId: String) =
-        animePlatformRepository.findByAnimePlatformAndId(animeUuid, platform, platformId)
+        repository.findByAnimePlatformAndId(animeUuid, platform, platformId)
 
     fun findByAnimePlatformAndId(anime: Anime, platform: Platform, platformId: String) =
         findByAnimePlatformAndId(anime.uuid!!, platform, platformId)

--- a/src/main/kotlin/fr/shikkanime/services/AnimeService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AnimeService.kt
@@ -25,7 +25,6 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 class AnimeService : AbstractService<Anime, AnimeRepository>() {
-    @Inject private lateinit var animeRepository: AnimeRepository
     @Inject private lateinit var simulcastCacheService: SimulcastCacheService
     @Inject private lateinit var configCacheService: ConfigCacheService
     @Inject private lateinit var simulcastService: SimulcastService
@@ -40,8 +39,6 @@ class AnimeService : AbstractService<Anime, AnimeRepository>() {
     @Inject private lateinit var platformFactory: PlatformFactory
     @Inject private lateinit var episodeMappingFactory: EpisodeMappingFactory
 
-    override fun getRepository() = animeRepository
-
     fun findAllBy(
         countryCode: CountryCode?,
         simulcastUuid: UUID?,
@@ -50,9 +47,9 @@ class AnimeService : AbstractService<Anime, AnimeRepository>() {
         sort: List<SortParameter>,
         page: Int,
         limit: Int,
-    ) = animeRepository.findAllBy(countryCode, simulcastUuid, name, searchTypes, sort, page, limit)
+    ) = repository.findAllBy(countryCode, simulcastUuid, name, searchTypes, sort, page, limit)
 
-    fun findAllBySimulcast(simulcastUuid: UUID) = animeRepository.findAllBySimulcast(simulcastUuid)
+    fun findAllBySimulcast(simulcastUuid: UUID) = repository.findAllBySimulcast(simulcastUuid)
 
     fun findAllNeedUpdate(): List<Anime> {
         val simulcasts = simulcastCacheService.findAll()
@@ -61,7 +58,7 @@ class AnimeService : AbstractService<Anime, AnimeRepository>() {
         val lastSeasonDelay = configCacheService.getValueAsInt(ConfigPropertyKey.UPDATE_ANIME_DELAY_LAST_SEASON, 30).toLong()
         val othersDelay = configCacheService.getValueAsInt(ConfigPropertyKey.UPDATE_ANIME_DELAY_OTHERS, 90).toLong()
 
-        return animeRepository.findAllNeedUpdate(
+        return repository.findAllNeedUpdate(
             currentSimulcastUuid = simulcasts.getOrNull(0)?.uuid,
             lastSimulcastUuid = simulcasts.getOrNull(1)?.uuid,
             currentSeasonDelay = currentSeasonDelay,
@@ -70,20 +67,30 @@ class AnimeService : AbstractService<Anime, AnimeRepository>() {
         )
     }
 
-    fun findAllAudioLocales(uuid: UUID) = animeRepository.findAllAudioLocales(uuid)
+    fun findAllAudioLocales(uuid: UUID) = repository.findAllAudioLocales(uuid)
 
-    fun findAllSeasons(uuid: UUID) = animeRepository.findAllSeasons(uuid)
+    fun findAllSeasons(uuid: UUID) = repository.findAllSeasons(uuid)
 
-    fun findAllSimulcastedWithAnimePlatformInvalid(simulcastUuids: Collection<UUID>, platform: Platform, lastValidateDateTime: ZonedDateTime, ignoreAudioLocale: String) = animeRepository.findAllSimulcastedWithAnimePlatformInvalid(simulcastUuids, platform, lastValidateDateTime, ignoreAudioLocale)
+    fun findAllSimulcastedWithAnimePlatformInvalid(
+        simulcastUuids: Collection<UUID>,
+        platform: Platform,
+        lastValidateDateTime: ZonedDateTime,
+        ignoreAudioLocale: String
+    ) = repository.findAllSimulcastedWithAnimePlatformInvalid(
+        simulcastUuids,
+        platform,
+        lastValidateDateTime,
+        ignoreAudioLocale
+    )
 
-    fun findAllSlugs() = animeRepository.findAllSlugs()
+    fun findAllSlugs() = repository.findAllSlugs()
 
-    fun preIndex() = animeRepository.preIndex()
+    fun preIndex() = repository.preIndex()
 
-    fun findBySlug(countryCode: CountryCode, slug: String) = animeRepository.findBySlug(countryCode, slug)
+    fun findBySlug(countryCode: CountryCode, slug: String) = repository.findBySlug(countryCode, slug)
 
     fun findByName(countryCode: CountryCode, name: String?) =
-        animeRepository.findByName(countryCode, name)
+        repository.findByName(countryCode, name)
 
     fun getWeeklyAnimes(
         countryCode: CountryCode,
@@ -206,9 +213,9 @@ class AnimeService : AbstractService<Anime, AnimeRepository>() {
     fun recalculateSimulcasts() {
         val ignoreEpisodeTypes = setOf(EpisodeType.SUMMARY)
 
-        animeRepository.deleteAllWithoutEpisodes()
+        repository.deleteAllWithoutEpisodes()
         episodeMappingService.updateAllReleaseDate()
-        animeRepository.updateAllReleaseDate()
+        repository.updateAllReleaseDate()
 
         val simulcastRange = configCacheService.getValueAsInt(ConfigPropertyKey.SIMULCAST_RANGE, 1)
         val simulcastRangeDelay = configCacheService.getValueAsInt(ConfigPropertyKey.SIMULCAST_RANGE_DELAY, 3)

--- a/src/main/kotlin/fr/shikkanime/services/AnimeTagService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AnimeTagService.kt
@@ -7,12 +7,9 @@ import fr.shikkanime.repositories.AnimeTagRepository
 import java.util.*
 
 class AnimeTagService : AbstractService<AnimeTag, AnimeTagRepository>() {
-    @Inject private lateinit var animeTagRepository: AnimeTagRepository
     @Inject private lateinit var traceActionService: TraceActionService
 
-    override fun getRepository() = animeTagRepository
-
-    fun findAllByAnime(animeUuid: UUID) = animeTagRepository.findAllByAnime(animeUuid)
+    fun findAllByAnime(animeUuid: UUID) = repository.findAllByAnime(animeUuid)
 
     override fun update(entity: AnimeTag): AnimeTag {
         val tag = super.update(entity)

--- a/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
@@ -35,23 +35,28 @@ class AttachmentService : AbstractService<Attachment, AttachmentRepository>() {
 
     @Volatile private var pendingInvalidation: ScheduledFuture<*>? = null
 
-    @Inject private lateinit var attachmentRepository: AttachmentRepository
     @Inject private lateinit var traceActionService: TraceActionService
     @Inject private lateinit var animeService: AnimeService
     @Inject private lateinit var episodeMappingService: EpisodeMappingService
     @Inject private lateinit var memberService: MemberService
 
-    override fun getRepository() = attachmentRepository
+    fun findAllByEntityUuidAndType(entityUuid: UUID, type: ImageType) =
+        repository.findAllByEntityUuidAndType(entityUuid, type)
 
-    fun findAllByEntityUuidAndType(entityUuid: UUID, type: ImageType) = attachmentRepository.findAllByEntityUuidAndType(entityUuid, type)
+    fun findAllNeededUpdate(lastUpdateDateTime: ZonedDateTime) = repository.findAllNeededUpdate(lastUpdateDateTime)
 
-    fun findAllNeededUpdate(lastUpdateDateTime: ZonedDateTime) = attachmentRepository.findAllNeededUpdate(lastUpdateDateTime)
+    fun findByEntityUuidTypeAndActive(entityUuid: UUID, type: ImageType) =
+        repository.findByEntityUuidTypeAndActive(entityUuid, type)
 
-    fun findByEntityUuidTypeAndActive(entityUuid: UUID, type: ImageType) = attachmentRepository.findByEntityUuidTypeAndActive(entityUuid, type)
+    fun findAllActiveWithUrlAndNotIn(uuids: HashSet<UUID>) = repository.findAllActiveWithUrlAndNotIn(uuids)
 
-    fun findAllActiveWithUrlAndNotIn(uuids: HashSet<UUID>) = attachmentRepository.findAllActiveWithUrlAndNotIn(uuids)
+    fun deleteAllByEntityUuid(entityUuid: UUID) {
+        val attachments = repository.findAllByEntityUuid(entityUuid)
+        attachments.forEach { getFile(it).delete() }
+        repository.deleteAll(attachments)
+    }
 
-    fun getAttachmentCountsByDate() = attachmentRepository.getCumulativeAttachmentCounts()
+    fun getAttachmentCountsByDate() = repository.getCumulativeAttachmentCounts()
 
     private fun scheduleInvalidation() {
         synchronized(this) {

--- a/src/main/kotlin/fr/shikkanime/services/ConfigService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/ConfigService.kt
@@ -8,14 +8,11 @@ import fr.shikkanime.repositories.ConfigRepository
 import java.util.*
 
 class ConfigService : AbstractService<Config, ConfigRepository>() {
-    @Inject private lateinit var configRepository: ConfigRepository
     @Inject private lateinit var traceActionService: TraceActionService
 
-    override fun getRepository() = configRepository
+    fun findAllByName(name: String) = repository.findAllByName(name)
 
-    fun findAllByName(name: String) = configRepository.findAllByName(name)
-
-    fun findByName(name: String) = configRepository.findByName(name)
+    fun findByName(name: String) = repository.findByName(name)
 
     fun update(uuid: UUID, configDto: ConfigDto): Config? {
         val config = find(uuid) ?: return null

--- a/src/main/kotlin/fr/shikkanime/services/EpisodeMappingService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/EpisodeMappingService.kt
@@ -13,14 +13,11 @@ import fr.shikkanime.services.caches.SimulcastCacheService
 import java.util.*
 
 class EpisodeMappingService : AbstractService<EpisodeMapping, EpisodeMappingRepository>() {
-    @Inject private lateinit var episodeMappingRepository: EpisodeMappingRepository
     @Inject private lateinit var episodeVariantService: EpisodeVariantService
     @Inject private lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
     @Inject private lateinit var traceActionService: TraceActionService
     @Inject private lateinit var simulcastCacheService: SimulcastCacheService
     @Inject private lateinit var configCacheService: ConfigCacheService
-
-    override fun getRepository() = episodeMappingRepository
 
     fun findAllBy(
         countryCode: CountryCode?,
@@ -30,11 +27,11 @@ class EpisodeMappingService : AbstractService<EpisodeMapping, EpisodeMappingRepo
         sort: List<SortParameter>,
         page: Int,
         limit: Int,
-    ) = episodeMappingRepository.findAllBy(countryCode, animeUuid, season, searchTypes, sort, page, limit)
+    ) = repository.findAllBy(countryCode, animeUuid, season, searchTypes, sort, page, limit)
 
-    fun findAllByAnime(anime: Anime) = episodeMappingRepository.findAllByAnime(anime.uuid!!)
+    fun findAllByAnime(anime: Anime) = repository.findAllByAnime(anime.uuid!!)
 
-    fun findAllByAnime(animeUuid: UUID) = episodeMappingRepository.findAllByAnime(animeUuid)
+    fun findAllByAnime(animeUuid: UUID) = repository.findAllByAnime(animeUuid)
 
     fun findAllNeedUpdate(): List<EpisodeMapping> {
         val simulcasts = simulcastCacheService.findAll()
@@ -44,7 +41,7 @@ class EpisodeMappingService : AbstractService<EpisodeMapping, EpisodeMappingRepo
         val othersDelay = configCacheService.getValueAsInt(ConfigPropertyKey.UPDATE_EPISODE_DELAY_OTHERS, 90).toLong()
         val lastImageUpdateDelay = configCacheService.getValueAsInt(ConfigPropertyKey.UPDATE_IMAGE_EPISODE_DELAY, 2).toLong()
 
-        return episodeMappingRepository.findAllNeedUpdate(
+        return repository.findAllNeedUpdate(
             currentSimulcastUuid = simulcasts.getOrNull(0)?.uuid,
             lastSimulcastUuid = simulcasts.getOrNull(1)?.uuid,
             currentSeasonDelay = currentSeasonDelay,
@@ -54,25 +51,25 @@ class EpisodeMappingService : AbstractService<EpisodeMapping, EpisodeMappingRepo
         )
     }
 
-    fun findAllSeo() = episodeMappingRepository.findAllSeo()
+    fun findAllSeo() = repository.findAllSeo()
 
     fun findAllSimulcasted(ignoreAudioLocale: String, ignoreEpisodeTypes: Set<EpisodeType>) =
-        episodeMappingRepository.findAllSimulcasted(ignoreAudioLocale, ignoreEpisodeTypes)
+        repository.findAllSimulcasted(ignoreAudioLocale, ignoreEpisodeTypes)
 
     fun findLastNumber(anime: Anime, episodeType: EpisodeType, season: Int, platform: Platform, audioLocale: String) =
-        episodeMappingRepository.findLastNumber(anime, episodeType, season, platform, audioLocale)
+        repository.findLastNumber(anime, episodeType, season, platform, audioLocale)
 
     fun findByAnimeSeasonEpisodeTypeNumber(animeUuid: UUID, season: Int, episodeType: EpisodeType, number: Int) =
-        episodeMappingRepository.findByAnimeSeasonEpisodeTypeNumber(animeUuid, season, episodeType, number)
+        repository.findByAnimeSeasonEpisodeTypeNumber(animeUuid, season, episodeType, number)
 
     fun findPreviousReleaseDateOfSimulcastedEpisodeMapping(anime: Anime, episode: EpisodeCalculateDto) =
-        episodeMappingRepository.findPreviousReleaseDateOfSimulcastedEpisodeMapping(anime, episode)
+        repository.findPreviousReleaseDateOfSimulcastedEpisodeMapping(anime, episode)
 
-    fun findMinimalReleaseDateTime() = episodeMappingRepository.findMinimalReleaseDateTime()
+    fun findMinimalReleaseDateTime() = repository.findMinimalReleaseDateTime()
 
-    fun updateAllReleaseDate() = episodeMappingRepository.updateAllReleaseDate()
+    fun updateAllReleaseDate() = repository.updateAllReleaseDate()
 
-    fun updateAllSimulcast(map: Map<UUID, UUID>) = episodeMappingRepository.updateAllSimulcast(map)
+    fun updateAllSimulcast(map: Map<UUID, UUID>) = repository.updateAllSimulcast(map)
 
     override fun save(entity: EpisodeMapping): EpisodeMapping {
         val save = super.save(entity)

--- a/src/main/kotlin/fr/shikkanime/services/EpisodeVariantService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/EpisodeVariantService.kt
@@ -18,7 +18,6 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 
 class EpisodeVariantService : AbstractService<EpisodeVariant, EpisodeVariantRepository>() {
-    @Inject private lateinit var episodeVariantRepository: EpisodeVariantRepository
     @Inject private lateinit var simulcastService: SimulcastService
     @Inject private lateinit var configCacheService: ConfigCacheService
     @Inject private lateinit var animeService: AnimeService
@@ -30,29 +29,27 @@ class EpisodeVariantService : AbstractService<EpisodeVariant, EpisodeVariantRepo
     @Inject private lateinit var attachmentService: AttachmentService
     @Inject private lateinit var mailService: MailService
 
-    override fun getRepository() = episodeVariantRepository
+    fun preIndex() = repository.preIndex()
 
-    fun preIndex() = episodeVariantRepository.preIndex()
+    fun findAllTypeIdentifier() = repository.findAllTypeIdentifier()
 
-    fun findAllTypeIdentifier() = episodeVariantRepository.findAllTypeIdentifier()
+    fun findAllByAnime(animeUuid: UUID) = repository.findAllByAnime(animeUuid)
 
-    fun findAllByAnime(animeUuid: UUID) = episodeVariantRepository.findAllByAnime(animeUuid)
-
-    fun findAllByMapping(mappingUUID: UUID) = episodeVariantRepository.findAllByMapping(mappingUUID)
+    fun findAllByMapping(mappingUUID: UUID) = repository.findAllByMapping(mappingUUID)
 
     fun findAllByMapping(mapping: EpisodeMapping) = findAllByMapping(mapping.uuid!!)
 
     fun findAllIdentifiersByMappingsAndPlatform(mappingUuids: Collection<UUID>, platform: Platform) =
-        episodeVariantRepository.findAllIdentifiersByMappingsAndPlatform(mappingUuids, platform)
+        repository.findAllIdentifiersByMappingsAndPlatform(mappingUuids, platform)
 
-    fun findAllIdentifiers() = episodeVariantRepository.findAllIdentifiers()
+    fun findAllIdentifiers() = repository.findAllIdentifiers()
 
     fun findAllVariantsByCountryCodeAndPlatformAndReleaseDateTimeBetween(
         countryCode: CountryCode,
         platform: Platform,
         startZonedDateTime: ZonedDateTime,
         endZonedDateTime: ZonedDateTime
-    ) = episodeVariantRepository.findAllVariantsByCountryCodeAndPlatformAndReleaseDateTimeBetween(
+    ) = repository.findAllVariantsByCountryCodeAndPlatformAndReleaseDateTimeBetween(
         countryCode,
         platform,
         startZonedDateTime,
@@ -215,7 +212,7 @@ class EpisodeVariantService : AbstractService<EpisodeVariant, EpisodeVariantRepo
         // Update the anime entity with the episode's data
         updateAnime(anime, episode, mapping)
 
-        if (episodeVariantRepository.findAllByMappingAndPlatformAndAudioLocaleAndUncensored(
+        if (repository.findAllByMappingAndPlatformAndAudioLocaleAndUncensored(
             mapping.uuid!!,
             episode.platform,
             episode.audioLocale,
@@ -288,7 +285,7 @@ class EpisodeVariantService : AbstractService<EpisodeVariant, EpisodeVariantRepo
         async: Boolean = true
     ): EpisodeMapping {
         // Try to find an existing mapping or create a new one
-        var mapping = episode.variantOf?.let { episodeVariantRepository.findByIdentifier(it)?.mapping }
+        var mapping = episode.variantOf?.let { repository.findByIdentifier(it)?.mapping }
             ?: episodeMappingService.findByAnimeSeasonEpisodeTypeNumber(
             anime.uuid!!,
             episode.season,

--- a/src/main/kotlin/fr/shikkanime/services/GenreService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/GenreService.kt
@@ -7,16 +7,13 @@ import fr.shikkanime.repositories.GenreRepository
 import java.util.*
 
 class GenreService : AbstractService<Genre, GenreRepository>() {
-    @Inject private lateinit var genreRepository: GenreRepository
     @Inject private lateinit var traceActionService: TraceActionService
 
-    override fun getRepository() = genreRepository
+    fun findAllByAnime(animeUuid: UUID) = repository.findAllByAnime(animeUuid)
 
-    fun findAllByAnime(animeUuid: UUID) = genreRepository.findAllByAnime(animeUuid)
+    fun findByName(name: String) = repository.findByName(name)
 
-    fun findByName(name: String) = genreRepository.findByName(name)
-
-    fun findOrSave(name: String) = genreRepository.findByName(name) ?: save(Genre(name = name))
+    fun findOrSave(name: String) = repository.findByName(name) ?: save(Genre(name = name))
 
     override fun save(entity: Genre): Genre {
         val genre = super.save(entity)

--- a/src/main/kotlin/fr/shikkanime/services/GroupedEpisodeService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/GroupedEpisodeService.kt
@@ -1,6 +1,5 @@
 package fr.shikkanime.services
 
-import com.google.inject.Inject
 import fr.shikkanime.entities.EpisodeMapping
 import fr.shikkanime.entities.enums.CountryCode
 import fr.shikkanime.entities.enums.LangType
@@ -8,15 +7,11 @@ import fr.shikkanime.entities.miscellaneous.SortParameter
 import fr.shikkanime.repositories.GroupedEpisodeRepository
 
 class GroupedEpisodeService : AbstractService<EpisodeMapping, GroupedEpisodeRepository>() {
-    @Inject private lateinit var groupedEpisodeRepository: GroupedEpisodeRepository
-
-    override fun getRepository() = groupedEpisodeRepository
-
     fun findAllBy(
         countryCode: CountryCode?,
         searchTypes: Array<LangType>?,
         sort: List<SortParameter>,
         page: Int,
         limit: Int
-    ) = groupedEpisodeRepository.findAllBy(countryCode, searchTypes, sort, page, limit)
+    ) = repository.findAllBy(countryCode, searchTypes, sort, page, limit)
 }

--- a/src/main/kotlin/fr/shikkanime/services/MailService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MailService.kt
@@ -14,12 +14,13 @@ import java.io.StringWriter
 class MailService : AbstractService<Mail, MailRepository>() {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Inject private lateinit var mailRepository: MailRepository
     @Inject private lateinit var configCacheService: ConfigCacheService
 
-    override fun getRepository() = mailRepository
+    fun findAllNotSent() = repository.findAllNotSent()
 
-    fun findAllNotSent() = mailRepository.findAllNotSent()
+    fun deleteAllByRecipient(recipient: String) {
+        repository.deleteAll(repository.findAllByRecipient(recipient))
+    }
 
     fun getFreemarkerContent(template: String, code: String? = null, model: Map<String, String>? = null): StringWriter {
         val stringWriter = StringWriter()

--- a/src/main/kotlin/fr/shikkanime/services/MemberActionService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MemberActionService.kt
@@ -22,29 +22,28 @@ class MemberActionService : AbstractService<MemberAction, MemberActionRepository
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Inject private lateinit var memberActionRepository: MemberActionRepository
     @Inject private lateinit var memberService: MemberService
     @Inject private lateinit var mailService: MailService
     @Inject private lateinit var traceActionService: TraceActionService
-
-    override fun getRepository() = memberActionRepository
 
     @OptIn(ExperimentalEncodingApi::class)
     private fun toWebToken(memberAction: MemberAction): String = EncryptionManager.toBase64(EncryptionManager.toSHA512("${memberAction.member?.uuid}|${memberAction.uuid}|${memberAction.action}|${memberAction.code}").toByteArray())
 
     fun validateWebAction(webToken: String) {
-        val actionTokens = memberActionRepository.findAllNotValidated().associateBy(this::toWebToken)
+        val actionTokens = repository.findAllNotValidated().associateBy(this::toWebToken)
         require(actionTokens.containsKey(webToken)) { "Action not found" }
         val memberAction = actionTokens[webToken] ?: return
         doValidateAction(memberAction)
     }
 
     fun validateAction(uuid: UUID, code: String) {
-        val memberAction = memberActionRepository.findByUuidAndCode(uuid, code)
+        val memberAction = repository.findByUuidAndCode(uuid, code)
         checkNotNull(memberAction) { "Invalid action" }
         require(ZonedDateTime.now() < memberAction.creationDateTime.plusMinutes(ACTION_EXPIRED_AFTER)) { "Action expired" }
         doValidateAction(memberAction)
     }
+
+    fun deleteAllByMember(memberUuid: UUID) = repository.deleteAll(repository.findAllByMember(memberUuid))
 
     fun save(action: Action, memberUuid: UUID, email: String): UUID {
         val code = StringUtils.generateRandomString(8).uppercase()
@@ -137,6 +136,6 @@ class MemberActionService : AbstractService<MemberAction, MemberActionRepository
 
         memberAction.validated = true
         memberAction.updateDateTime = ZonedDateTime.now()
-        memberActionRepository.update(memberAction)
+        repository.update(memberAction)
     }
 }

--- a/src/main/kotlin/fr/shikkanime/services/MemberFollowAnimeService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MemberFollowAnimeService.kt
@@ -12,31 +12,33 @@ import fr.shikkanime.utils.routes.Response
 import java.util.*
 
 class MemberFollowAnimeService : AbstractService<MemberFollowAnime, MemberFollowAnimeRepository>() {
-    @Inject private lateinit var memberFollowAnimeRepository: MemberFollowAnimeRepository
-
     @Inject
     private lateinit var memberService: MemberService
     @Inject private lateinit var animeService: AnimeService
     @Inject private lateinit var traceActionService: TraceActionService
 
-    override fun getRepository() = memberFollowAnimeRepository
+    fun findAllFollowedAnimes(memberUuid: UUID, page: Int, limit: Int) =
+        repository.findAllFollowedAnimes(memberUuid, page, limit)
 
-    fun findAllFollowedAnimes(memberUuid: UUID, page: Int, limit: Int) = memberFollowAnimeRepository.findAllFollowedAnimes(memberUuid, page, limit)
+    fun findAllFollowedAnimesUUID(memberUuid: UUID) = repository.findAllFollowedAnimesUUID(memberUuid)
 
-    fun findAllFollowedAnimesUUID(memberUuid: UUID) = memberFollowAnimeRepository.findAllFollowedAnimesUUID(memberUuid)
-
-    fun findAllByAnime(anime: Anime) = memberFollowAnimeRepository.findAllByAnime(anime)
+    fun findAllByAnime(anime: Anime) = repository.findAllByAnime(anime)
 
     fun findAllMissedAnimes(memberUuid: UUID, page: Int, limit: Int) =
-        memberFollowAnimeRepository.findAllMissedAnimes(memberUuid, page, limit)
+        repository.findAllMissedAnimes(memberUuid, page, limit)
 
-    fun existsByMemberUuidAndAnimeUuid(memberUuid: UUID, animeUuid: UUID) = memberFollowAnimeRepository.existsByMemberUuidAndAnimeUuid(memberUuid, animeUuid)
+    fun findAllByMember(memberUuid: UUID) = repository.findAllByMember(memberUuid)
+
+    fun existsByMemberUuidAndAnimeUuid(memberUuid: UUID, animeUuid: UUID) =
+        repository.existsByMemberUuidAndAnimeUuid(memberUuid, animeUuid)
 
     fun existsByMemberAndAnime(member: Member, anime: Anime) = existsByMemberUuidAndAnimeUuid(member.uuid!!, anime.uuid!!)
 
+    fun deleteAllByMember(memberUuid: UUID) = repository.deleteAll(repository.findAllByMember(memberUuid))
+
     fun follow(memberUuid: UUID, anime: GenericDto): Response {
         val animeReference = animeService.getReference(anime.uuid) ?: return Response.notFound()
-        if (memberFollowAnimeRepository.existsByMemberUuidAndAnimeUuid(memberUuid, animeReference.uuid!!))
+        if (repository.existsByMemberUuidAndAnimeUuid(memberUuid, animeReference.uuid!!))
             return Response.conflict()
 
         val memberFollowAnime = save(MemberFollowAnime(member = memberService.getReference(memberUuid), anime = animeReference))
@@ -46,10 +48,10 @@ class MemberFollowAnimeService : AbstractService<MemberFollowAnime, MemberFollow
     }
 
     fun unfollow(memberUuid: UUID, anime: GenericDto): Response {
-        val memberFollowAnime = memberFollowAnimeRepository.findByMemberUuidAndAnimeUuid(memberUuid, anime.uuid)
+        val memberFollowAnime = repository.findByMemberUuidAndAnimeUuid(memberUuid, anime.uuid)
             ?: return Response.conflict()
 
-        memberFollowAnimeRepository.delete(memberFollowAnime)
+        repository.delete(memberFollowAnime)
         traceActionService.createTraceAction(memberFollowAnime, TraceAction.Action.DELETE)
         InvalidationService.invalidate(MemberFollowAnime::class.java)
         return Response.ok()

--- a/src/main/kotlin/fr/shikkanime/services/MemberFollowEpisodeService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MemberFollowEpisodeService.kt
@@ -15,26 +15,27 @@ import java.time.ZonedDateTime
 import java.util.*
 
 class MemberFollowEpisodeService : AbstractService<MemberFollowEpisode, MemberFollowEpisodeRepository>() {
-    @Inject private lateinit var memberFollowEpisodeRepository: MemberFollowEpisodeRepository
-
     @Inject
     private lateinit var memberService: MemberService
     @Inject private lateinit var episodeMappingService: EpisodeMappingService
     @Inject private lateinit var traceActionService: TraceActionService
 
-    override fun getRepository() = memberFollowEpisodeRepository
+    fun findAllFollowedEpisodes(memberUuid: UUID, page: Int, limit: Int) =
+        repository.findAllFollowedEpisodes(memberUuid, page, limit)
 
-    fun findAllFollowedEpisodes(memberUuid: UUID, page: Int, limit: Int) = memberFollowEpisodeRepository.findAllFollowedEpisodes(memberUuid, page, limit)
-
-    fun findAllFollowedEpisodesUUID(memberUuid: UUID) = memberFollowEpisodeRepository.findAllFollowedEpisodesUUID(memberUuid)
+    fun findAllFollowedEpisodesUUID(memberUuid: UUID) = repository.findAllFollowedEpisodesUUID(memberUuid)
 
     fun findAllByEpisode(episodeMapping: EpisodeMapping) =
-        memberFollowEpisodeRepository.findAllByEpisode(episodeMapping)
+        repository.findAllByEpisode(episodeMapping)
 
-    fun getSeenAndUnseenDuration(member: Member) = memberFollowEpisodeRepository.getSeenAndUnseenDuration(member)
+    fun findAllByMember(memberUuid: UUID) = repository.findAllByMember(memberUuid)
+
+    fun getSeenAndUnseenDuration(member: Member) = repository.getSeenAndUnseenDuration(member)
+
+    fun deleteAllByMember(memberUuid: UUID) = repository.deleteAll(repository.findAllByMember(memberUuid))
 
     fun followAll(memberUuid: UUID, anime: GenericDto): Response {
-        val nonFollowedEpisodes = memberFollowEpisodeRepository
+        val nonFollowedEpisodes = repository
             .findAllNonFollowedEpisodesByMemberUuidAndAnimeUuid(memberUuid, anime.uuid)
             .takeIfNotEmpty() ?: return Response.ok(AllFollowedEpisodeDto(emptySet(), 0))
 
@@ -55,7 +56,7 @@ class MemberFollowEpisodeService : AbstractService<MemberFollowEpisode, MemberFo
 
     fun follow(memberUuid: UUID, episode: GenericDto): Response {
         val episodeReference = episodeMappingService.getReference(episode.uuid) ?: return Response.notFound()
-        if (memberFollowEpisodeRepository.existsByMemberUuidAndEpisodeUuid(memberUuid, episodeReference.uuid!!))
+        if (repository.existsByMemberUuidAndEpisodeUuid(memberUuid, episodeReference.uuid!!))
             return Response.conflict()
 
         val memberFollowEpisode =
@@ -66,10 +67,10 @@ class MemberFollowEpisodeService : AbstractService<MemberFollowEpisode, MemberFo
     }
 
     fun unfollow(memberUuid: UUID, episode: GenericDto): Response {
-        val memberFollowEpisode = memberFollowEpisodeRepository.findByMemberUuidAndEpisodeUuid(memberUuid, episode.uuid)
+        val memberFollowEpisode = repository.findByMemberUuidAndEpisodeUuid(memberUuid, episode.uuid)
             ?: return Response.conflict()
 
-        memberFollowEpisodeRepository.delete(memberFollowEpisode)
+        repository.delete(memberFollowEpisode)
         traceActionService.createTraceAction(memberFollowEpisode, TraceAction.Action.DELETE)
         InvalidationService.invalidate(MemberFollowEpisode::class.java)
         return Response.ok()

--- a/src/main/kotlin/fr/shikkanime/services/MemberService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MemberService.kt
@@ -25,11 +25,15 @@ class MemberService : AbstractService<Member, MemberRepository>() {
 
     @Inject private lateinit var memberRepository: MemberRepository
     @Inject private lateinit var memberActionService: MemberActionService
+    @Inject
+    private lateinit var memberFollowAnimeService: MemberFollowAnimeService
+    @Inject
+    private lateinit var memberFollowEpisodeService: MemberFollowEpisodeService
+    @Inject
+    private lateinit var mailService: MailService
     @Inject private lateinit var traceActionService: TraceActionService
     @Inject private lateinit var memberFactory: MemberFactory
     @Inject private lateinit var attachmentService: AttachmentService
-
-    override fun getRepository() = memberRepository
 
     private fun findAllByRoles(roles: List<Role>) = memberRepository.findAllByRoles(roles)
 
@@ -112,6 +116,20 @@ class MemberService : AbstractService<Member, MemberRepository>() {
         requireNotNull(member.email)
         // Creation member action
         return memberActionService.save(Action.FORGOT_IDENTIFIER, member.uuid!!, member.email!!)
+    }
+
+    override fun delete(entity: Member) {
+        val memberUuid = entity.uuid!!
+
+        memberFollowAnimeService.deleteAllByMember(memberUuid)
+        memberFollowEpisodeService.deleteAllByMember(memberUuid)
+        memberActionService.deleteAllByMember(memberUuid)
+        traceActionService.deleteAllByEntityUuid(memberUuid)
+        attachmentService.deleteAllByEntityUuid(memberUuid)
+        entity.email?.let { mailService.deleteAllByRecipient(it) }
+
+        super.delete(entity)
+        InvalidationService.invalidate(Member::class.java)
     }
 
     suspend fun changeProfileImage(member: Member, multiPartData: MultiPartData) {

--- a/src/main/kotlin/fr/shikkanime/services/MetricService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MetricService.kt
@@ -1,16 +1,11 @@
 package fr.shikkanime.services
 
-import com.google.inject.Inject
 import fr.shikkanime.dtos.GroupedMetricDto
 import fr.shikkanime.entities.Metric
 import fr.shikkanime.repositories.MetricRepository
 import java.time.ZonedDateTime
 
 class MetricService : AbstractService<Metric, MetricRepository>() {
-    @Inject private lateinit var metricRepository: MetricRepository
-
-    override fun getRepository() = metricRepository
-
     fun findAllAfterGrouped(hours: Long): List<GroupedMetricDto> {
         val date = ZonedDateTime.now().minusHours(hours)
         
@@ -21,9 +16,9 @@ class MetricService : AbstractService<Metric, MetricRepository>() {
             168L -> "day"      // Last week: group by day
             else -> "day" // Default to day for longer periods
         }
-        
-        return metricRepository.findAllAfterGrouped(date, groupByMinute)
+
+        return repository.findAllAfterGrouped(date, groupByMinute)
     }
 
-    fun deleteAllBefore(date: ZonedDateTime) = metricRepository.deleteAllBefore(date)
+    fun deleteAllBefore(date: ZonedDateTime) = repository.deleteAllBefore(date)
 }

--- a/src/main/kotlin/fr/shikkanime/services/RuleService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/RuleService.kt
@@ -6,10 +6,7 @@ import fr.shikkanime.entities.TraceAction
 import fr.shikkanime.repositories.RuleRepository
 
 class RuleService : AbstractService<Rule, RuleRepository>() {
-    @Inject private lateinit var ruleRepository: RuleRepository
     @Inject private lateinit var traceActionService: TraceActionService
-
-    override fun getRepository() = ruleRepository
 
     override fun save(entity: Rule): Rule {
         val rule = super.save(entity)

--- a/src/main/kotlin/fr/shikkanime/services/SimulcastService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/SimulcastService.kt
@@ -13,13 +13,10 @@ import jakarta.persistence.Tuple
 import java.time.ZonedDateTime
 
 class SimulcastService : AbstractService<Simulcast, SimulcastRepository>() {
-    @Inject private lateinit var simulcastRepository: SimulcastRepository
     @Inject private lateinit var traceActionService: TraceActionService
     @Inject private lateinit var simulcastFactory: SimulcastFactory
 
-    override fun getRepository() = simulcastRepository
-
-    fun findAllModified() = simulcastRepository.findAllModified()
+    fun findAllModified() = repository.findAllModified()
         .sortedWith(compareBy<Tuple>({ it[0, Simulcast::class.java].year }, { Season.entries.indexOf(it[0, Simulcast::class.java].season) }).reversed())
         .map {
             simulcastFactory.toDto(it[0, Simulcast::class.java]).apply {
@@ -28,7 +25,7 @@ class SimulcastService : AbstractService<Simulcast, SimulcastRepository>() {
             }
         }
 
-    fun findBySeasonAndYear(season: Season, year: Int) = simulcastRepository.findBySeasonAndYear(season, year)
+    fun findBySeasonAndYear(season: Season, year: Int) = repository.findBySeasonAndYear(season, year)
 
     override fun save(entity: Simulcast): Simulcast {
         val save = super.save(entity)

--- a/src/main/kotlin/fr/shikkanime/services/TagService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/TagService.kt
@@ -6,14 +6,11 @@ import fr.shikkanime.entities.TraceAction
 import fr.shikkanime.repositories.TagRepository
 
 class TagService : AbstractService<Tag, TagRepository>() {
-    @Inject private lateinit var tagRepository: TagRepository
     @Inject private lateinit var traceActionService: TraceActionService
 
-    override fun getRepository() = tagRepository
+    fun findByName(name: String) = repository.findByName(name)
 
-    fun findByName(name: String) = tagRepository.findByName(name)
-
-    fun findOrSave(name: String) = tagRepository.findByName(name) ?: save(Tag(name = name))
+    fun findOrSave(name: String) = repository.findByName(name) ?: save(Tag(name = name))
 
     override fun save(entity: Tag): Tag {
         val tag = super.save(entity)

--- a/src/main/kotlin/fr/shikkanime/services/TraceActionService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/TraceActionService.kt
@@ -1,6 +1,5 @@
 package fr.shikkanime.services
 
-import com.google.inject.Inject
 import fr.shikkanime.dtos.analytics.KeyCountDto
 import fr.shikkanime.entities.ShikkEntity
 import fr.shikkanime.entities.TraceAction
@@ -8,6 +7,7 @@ import fr.shikkanime.repositories.TraceActionRepository
 import fr.shikkanime.utils.Constant
 import java.time.LocalDate
 import java.time.ZonedDateTime
+import java.util.*
 
 class TraceActionService : AbstractService<TraceAction, TraceActionRepository>() {
     data class DateVersionCountDto(
@@ -24,21 +24,22 @@ class TraceActionService : AbstractService<TraceAction, TraceActionRepository>()
         val dailyWmaCounts: List<KeyCountDto>
     )
 
-    @Inject private lateinit var traceActionRepository: TraceActionRepository
+    fun findAllBy(entityType: String?, action: String?, page: Int, limit: Int) =
+        repository.findAllBy(entityType, action, page, limit)
 
-    override fun getRepository() = traceActionRepository
+    fun findAllByEntityUuid(entityUuid: UUID) = repository.findAllByEntityUuid(entityUuid)
 
-    fun findAllBy(entityType: String?, action: String?, page: Int, limit: Int) = traceActionRepository.findAllBy(entityType, action, page, limit)
+    fun deleteAllByEntityUuid(entityUuid: UUID) = repository.deleteAll(repository.findAllByEntityUuid(entityUuid))
 
     fun getUserAnalytics(date: LocalDate, minActiveDays: Int = 2): AnalyticsReport {
         val since = date.atStartOfDay(Constant.utcZoneId)
-        val uuids = traceActionRepository.getReturningUserUuids(since, minActiveDays)
-        val lastLoginUuids = traceActionRepository.findLastLoginsByEntityUuids(uuids)
-        val versionCounts = traceActionRepository.getAppVersionCount(since, lastLoginUuids)
-        val localeCounts = traceActionRepository.getLocaleCount(since, lastLoginUuids)
-        val deviceCounts = traceActionRepository.getDeviceCount(since, lastLoginUuids)
-        val dailyUserVersionCounts = traceActionRepository.getDailyReturningUserCount(since, uuids)
-        val dailyWmaCounts = traceActionRepository.getDailyWmaCount(since, uuids)
+        val uuids = repository.getReturningUserUuids(since, minActiveDays)
+        val lastLoginUuids = repository.findLastLoginsByEntityUuids(uuids)
+        val versionCounts = repository.getAppVersionCount(since, lastLoginUuids)
+        val localeCounts = repository.getLocaleCount(since, lastLoginUuids)
+        val deviceCounts = repository.getDeviceCount(since, lastLoginUuids)
+        val dailyUserVersionCounts = repository.getDailyReturningUserCount(since, uuids)
+        val dailyWmaCounts = repository.getDailyWmaCount(since, uuids)
         return AnalyticsReport(versionCounts, localeCounts, deviceCounts, dailyUserVersionCounts, dailyWmaCounts)
     }
 

--- a/src/main/kotlin/fr/shikkanime/utils/Database.kt
+++ b/src/main/kotlin/fr/shikkanime/utils/Database.kt
@@ -80,7 +80,9 @@ class Database {
     @Suppress("unused")
     constructor() : this(
         File(
-            ClassLoader.getSystemClassLoader().getResource("hibernate.cfg.xml")?.file ?: "hibernate.cfg.xml"
+            (Database::class.java.classLoader.getResource("hibernate.cfg.xml")
+                ?: Thread.currentThread().contextClassLoader.getResource("hibernate.cfg.xml"))?.file
+                ?: "hibernate.cfg.xml"
         )
     )
 

--- a/src/main/resources/templates/admin/members/edit.ftl
+++ b/src/main/resources/templates/admin/members/edit.ftl
@@ -14,6 +14,15 @@
             });
 
             this.member.email = null;
+        },
+        async deleteMember() {
+            if (!confirm('Are you sure you want to delete this member and all its data? (GDPR)')) return;
+
+            await fetch('/admin/api/members/' + getUuid(), {
+                method: 'DELETE'
+            });
+
+            window.location.href = '/admin/members';
         }
     }" x-init="member = await loadMember(); animes = await getAnimes(); episodes = await getEpisodes()" class="d-flex flex-column dashboard-wrapper pb-3">
 
@@ -22,8 +31,9 @@
             <div class="card-body py-3 px-4">
                 <div class="d-flex align-items-md-center gap-4 flex-column flex-md-row">
                     <!-- Actions -->
-                    <div class="flex-shrink-0">
+                    <div class="flex-shrink-0 d-flex gap-2">
                         <a class="btn btn-secondary ms-0" @click="window.history.back()">Back</a>
+                        <button class="btn btn-danger" @click="deleteMember()">Delete (GDPR)</button>
                     </div>
 
                     <!-- Avatar -->

--- a/src/test/kotlin/fr/shikkanime/CacheVerificationTest.kt
+++ b/src/test/kotlin/fr/shikkanime/CacheVerificationTest.kt
@@ -1,0 +1,30 @@
+package fr.shikkanime
+
+import org.hibernate.SessionFactory
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import javax.cache.Caching
+
+class CacheVerificationTest : AbstractTest() {
+
+    @Test
+    fun testEhcacheIsLoaded() {
+        // 1. Vérifier que le cache de second niveau est activé dans Hibernate
+        val sessionFactory = database.entityManager.entityManagerFactory.unwrap(SessionFactory::class.java)
+        assertTrue(sessionFactory.getCache() != null, "Le cache Hibernate devrait être disponible")
+
+        // 2. Vérifier que le CacheManager JCache (Ehcache) a bien chargé les régions de ehcache.xml
+        val provider = Caching.getCachingProvider()
+        val cacheManager = provider.cacheManager
+        val cacheNames = cacheManager.cacheNames.toList()
+
+        // "default-query-results-region" et "org.hibernate.cache.spi.UpdateTimestampsCache" sont définis dans ehcache.xml
+        // Leur présence prouve que le fichier a été lu et appliqué.
+        assertTrue(
+            cacheNames.contains("default-query-results-region"),
+            "Le fichier ehcache.xml devrait être chargé. Caches trouvés : $cacheNames"
+        )
+
+        println("Vérification réussie : ehcache.xml est bien chargé et utilisé par Hibernate.")
+    }
+}

--- a/src/test/kotlin/fr/shikkanime/services/MemberServiceTest.kt
+++ b/src/test/kotlin/fr/shikkanime/services/MemberServiceTest.kt
@@ -1,7 +1,9 @@
 package fr.shikkanime.services
 
 import fr.shikkanime.AbstractTest
-import fr.shikkanime.entities.Member
+import fr.shikkanime.entities.*
+import fr.shikkanime.entities.enums.CountryCode
+import fr.shikkanime.entities.enums.EpisodeType
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -25,5 +27,42 @@ class MemberServiceTest : AbstractTest() {
         val updatedMember = memberService.find(saved.uuid)
         assertNotNull(updatedMember)
         assertNull(updatedMember!!.email)
+    }
+
+    @Test
+    fun deleteGDPR() {
+        val member = memberService.save(
+            Member(
+                username = "testuser",
+                email = "test@example.com",
+                encryptedPassword = byteArrayOf()
+            )
+        )
+        val memberUuid = member.uuid!!
+
+        val anime = animeService.save(Anime(countryCode = CountryCode.FR, name = "Test Anime", slug = "test-anime"))
+        val episode = episodeMappingService.save(
+            EpisodeMapping(
+                anime = anime,
+                episodeType = EpisodeType.EPISODE,
+                season = 1,
+                number = 1
+            )
+        )
+
+        memberFollowAnimeService.save(MemberFollowAnime(member = member, anime = anime))
+        memberFollowEpisodeService.save(MemberFollowEpisode(member = member, episode = episode))
+        traceActionService.createTraceAction(member, TraceAction.Action.LOGIN)
+
+        assertFalse(memberFollowAnimeService.findAllByMember(memberUuid).isEmpty())
+        assertFalse(memberFollowEpisodeService.findAllByMember(memberUuid).isEmpty())
+        assertFalse(traceActionService.findAllByEntityUuid(memberUuid).isEmpty())
+
+        memberService.delete(member)
+
+        assertNull(memberService.find(memberUuid))
+        assertTrue(memberFollowAnimeService.findAllByMember(memberUuid).isEmpty())
+        assertTrue(memberFollowEpisodeService.findAllByMember(memberUuid).isEmpty())
+        assertTrue(traceActionService.findAllByEntityUuid(memberUuid).isEmpty())
     }
 }

--- a/src/test/resources/hibernate.cfg.xml
+++ b/src/test/resources/hibernate.cfg.xml
@@ -23,6 +23,7 @@
         <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.region.factory_class">jcache</property>
         <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.jcache.cache_manager_uri">classpath:ehcache.xml</property>
         <property name="hibernate.javax.cache.missing_cache_strategy">create</property>
     </session-factory>
 </hibernate-configuration>


### PR DESCRIPTION
- Added `deleteMember` frontend logic with confirmation prompt in `edit.ftl` for GDPR compliance.
- Introduced `deleteMember` endpoint in `MemberController` for backend support.
- Enhanced `MemberService` to handle cascading deletions of related entities (follows, actions, attachments, etc.).
- Updated repositories (`AttachmentRepository`, `MailRepository`, `MemberFollowAnimeRepository`, etc.) with bulk deletion methods.
- Added `deleteGDPR` test in `MemberServiceTest` to validate GDPR deletion functionality.
- Refactored services to replace direct repository injections with inherited `AbstractService.repository`.