### PR TITLE
Update Crunchyroll basic auth token

### DIFF
--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractCrunchyrollWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractCrunchyrollWrapper.kt
@@ -361,7 +361,7 @@ abstract class AbstractCrunchyrollWrapper {
     companion object {
         const val CRUNCHYROLL_CHUNK = 100
         // Updated automatically by the update-credentials GitHub Actions workflow - do not edit manually
-        const val CRUNCHYROLL_BASIC_AUTH_TOKEN_DEFAULT = "eTJhcnZqYjBoMHJndnRpemxvdnk6SlZMdndkSXBYdnhVLXFJQnZUMU04b1FUcjFxbFFKWDI="
-        const val CRUNCHYROLL_APK_VERSION = "3.59.0_22338"
+        const val CRUNCHYROLL_BASIC_AUTH_TOKEN_DEFAULT = "bm1oaGcwbDZ4eXhjZm02aHQ2aGY6SjR6bU1mdjNkMVFkWHk4dDk2d1NjeDdoUnkzclBHLTM="
+        const val CRUNCHYROLL_APK_VERSION = "3.61.0_22341"
     }
 }


### PR DESCRIPTION
Update the Crunchyroll basic auth token default value to match the latest Android TV APK (`3.61.0_22341`).

The token can also be overridden at runtime via the `crunchyroll_basic_auth_token` configuration key without requiring a deployment.