### PR TITLE
feat: add thread monitoring metrics and optimize HttpRequest usage

### DIFF
--- a/src/main/kotlin/fr/shikkanime/dtos/GroupedMetricDto.kt
+++ b/src/main/kotlin/fr/shikkanime/dtos/GroupedMetricDto.kt
@@ -3,5 +3,7 @@ package fr.shikkanime.dtos
 data class GroupedMetricDto(
     val date: String,
     val avgCpuLoad: String,
-    val avgMemoryUsage: String
+    val avgMemoryUsage: String,
+    val avgThreadCount: String,
+    val maxPeakThreadCount: String
 )

--- a/src/main/kotlin/fr/shikkanime/entities/Metric.kt
+++ b/src/main/kotlin/fr/shikkanime/entities/Metric.kt
@@ -20,6 +20,10 @@ class Metric(
     val cpuLoad: Double = 0.0,
     @Column(name = "memory_usage")
     val memoryUsage: Long = 0,
+    @Column(name = "thread_count")
+    val threadCount: Int = 0,
+    @Column(name = "peak_thread_count")
+    val peakThreadCount: Int = 0,
     @Column(nullable = false)
     val date: ZonedDateTime = ZonedDateTime.now(),
 ) : ShikkEntity(uuid)

--- a/src/main/kotlin/fr/shikkanime/jobs/MetricJob.kt
+++ b/src/main/kotlin/fr/shikkanime/jobs/MetricJob.kt
@@ -11,10 +11,14 @@ class MetricJob : AbstractJob {
     @Inject private lateinit var metricService: MetricService
 
     override suspend fun run() {
+        val threadMXBean = ManagementFactory.getThreadMXBean()
+
         metricService.save(
             Metric(
                 cpuLoad = getProcessCPULoad(),
                 memoryUsage = getProcessMemoryUsage(),
+                threadCount = threadMXBean.threadCount,
+                peakThreadCount = threadMXBean.peakThreadCount,
             )
         )
     }

--- a/src/main/kotlin/fr/shikkanime/repositories/MetricRepository.kt
+++ b/src/main/kotlin/fr/shikkanime/repositories/MetricRepository.kt
@@ -21,6 +21,8 @@ class MetricRepository : AbstractRepository<Metric>() {
                     groupedDate,
                     cb.avg(root[Metric_.cpuLoad]),
                     cb.avg(root[Metric_.memoryUsage]),
+                    cb.avg(root[Metric_.threadCount]),
+                    cb.max(root[Metric_.peakThreadCount]),
                 )
             )
 
@@ -34,7 +36,9 @@ class MetricRepository : AbstractRepository<Metric>() {
                     GroupedMetricDto(
                         date = tuple[0, ZonedDateTime::class.java].withUTCString(),
                         avgCpuLoad = (tuple[1, Double::class.java] * 100).toString().replace(',', '.'),
-                        avgMemoryUsage = (tuple[2, Double::class.java] / 1024.0 / 1024.0).toString().replace(',', '.')
+                        avgMemoryUsage = (tuple[2, Double::class.java] / 1024.0 / 1024.0).toString().replace(',', '.'),
+                        avgThreadCount = tuple[3, Double::class.java].toString().replace(',', '.'),
+                        maxPeakThreadCount = tuple[4, Int::class.java].toString()
                     )
                 }
         }

--- a/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
+++ b/src/main/kotlin/fr/shikkanime/services/AttachmentService.kt
@@ -27,7 +27,6 @@ class AttachmentService : AbstractService<Attachment, AttachmentRepository>() {
     private val nThreads = Runtime.getRuntime().availableProcessors()
     private var threadPool = Executors.newFixedThreadPool(nThreads)
     private var invalidationScheduler = Executors.newSingleThreadScheduledExecutor()
-    private val httpRequest = HttpRequest()
     private val imageCache = LRUCache<UUID, ByteArray>(100)
     val inProgressAttachments: MutableSet<UUID> = Collections.synchronizedSet(HashSet())
     private val contentTypes = listOf(ContentType.Image.PNG, ContentType.Image.JPEG, ContentType.parse("image/jpg"))
@@ -189,7 +188,7 @@ class AttachmentService : AbstractService<Attachment, AttachmentRepository>() {
             if (!url.isNullOrBlank() && bytes.isNullOrEmpty()) {
                 val (httpResponse, urlBytes) = runBlocking {
                     val response = HttpRequest.retryOnTimeout(3) {
-                        httpRequest.get(
+                        HttpRequest.get(
                             url,
                             headers = mapOf("User-Agent" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36")
                         )

--- a/src/main/kotlin/fr/shikkanime/services/MediaImage.kt
+++ b/src/main/kotlin/fr/shikkanime/services/MediaImage.kt
@@ -19,7 +19,6 @@ import javax.imageio.ImageIO
 object MediaImage {
     private const val BLUR_SIZE = 25
     private val blurKernel = FloatArray(BLUR_SIZE * BLUR_SIZE) { 1f / (BLUR_SIZE * BLUR_SIZE) }
-    private val httpRequest = HttpRequest(timeout = 5_000L)
 
     suspend fun toMediaImage(episodes: List<GroupedEpisode>): BufferedImage {
         require(episodes.isNotEmpty()) { "The grouped episodes list is empty" }
@@ -206,7 +205,7 @@ object MediaImage {
     }
 
     suspend fun getLongTimeoutImage(url: String): BufferedImage =
-        ByteArrayInputStream(HttpRequest.retryOnTimeout(3) { httpRequest.get(url).readRawBytes() }).use {
+        ByteArrayInputStream(HttpRequest.retryOnTimeout(3) { HttpRequest.get(url, timeout = 5000L).readRawBytes() }).use {
             ImageIO.read(
                 it
             )

--- a/src/main/kotlin/fr/shikkanime/services/caches/BotDetectorCache.kt
+++ b/src/main/kotlin/fr/shikkanime/services/caches/BotDetectorCache.kt
@@ -16,7 +16,6 @@ import kotlin.experimental.and
 
 class BotDetectorCache : ICacheService {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val httpRequest = HttpRequest()
     private val ipv4Regex = Regex("(?:[0-9]{1,3}\\.){3}[0-9]{1,3}(?:/[0-9]+)*")
 
     @Inject private lateinit var configCacheService: ConfigCacheService
@@ -54,7 +53,7 @@ class BotDetectorCache : ICacheService {
         key = StringUtils.EMPTY_STRING
     ) {
         val response =
-            httpRequest.get("https://raw.githubusercontent.com/AnTheMaker/GoodBots/refs/heads/main/all.ips")
+            HttpRequest.get("https://raw.githubusercontent.com/AnTheMaker/GoodBots/refs/heads/main/all.ips")
 
         if (response.status != HttpStatusCode.OK) {
             logger.severe("Failed to fetch good bots IPs: ${response.status}")
@@ -69,7 +68,7 @@ class BotDetectorCache : ICacheService {
         typeToken = object : TypeToken<MapCacheValue<CopyOnWriteArraySet<String>>>() {},
         key = StringUtils.EMPTY_STRING
     ) {
-        val response = httpRequest.get("https://raw.githubusercontent.com/matomo-org/device-detector/refs/heads/master/regexes/bots.yml")
+        val response = HttpRequest.get("https://raw.githubusercontent.com/matomo-org/device-detector/refs/heads/master/regexes/bots.yml")
 
         if (response.status != HttpStatusCode.OK) {
             logger.severe("Failed to fetch good bots regex: ${response.status}")
@@ -90,7 +89,7 @@ class BotDetectorCache : ICacheService {
         key = StringUtils.EMPTY_STRING
     ) {
         val response =
-            httpRequest.get("https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/main/abuseipdb-s100-30d.ipv4")
+            HttpRequest.get("https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/main/abuseipdb-s100-30d.ipv4")
 
         if (response.status != HttpStatusCode.OK) {
             logger.severe("Failed to fetch abuse IPs: ${response.status}")

--- a/src/main/kotlin/fr/shikkanime/utils/HttpRequest.kt
+++ b/src/main/kotlin/fr/shikkanime/utils/HttpRequest.kt
@@ -19,13 +19,9 @@ import kotlin.time.Duration.Companion.milliseconds
 
 private val logger = LoggerFactory.getLogger(HttpRequest::class.java)
 
-class HttpRequest(private val timeout: Long = 60_000) {
-    private fun httpClient() = HttpClient(OkHttp) {
-        install(HttpTimeout) {
-            requestTimeoutMillis = timeout
-            connectTimeoutMillis = timeout
-            socketTimeoutMillis = timeout
-        }
+object HttpRequest {
+    private val client = HttpClient(OkHttp) {
+        install(HttpTimeout)
         install(ContentNegotiation) {
             json(Json {
                 ignoreUnknownKeys = true
@@ -38,13 +34,16 @@ class HttpRequest(private val timeout: Long = 60_000) {
         }
     }
 
-    suspend fun get(url: String, headers: Map<String, String> = emptyMap()): HttpResponse {
+    suspend fun get(url: String, headers: Map<String, String> = emptyMap(), timeout: Long = 60_000): HttpResponse {
         logger.info("Making request to $url... (GET)")
         val start = System.currentTimeMillis()
 
-        val response = httpClient().use {
-            it.get(url) {
-                headers.forEach(::header)
+        val response = client.get(url) {
+            headers.forEach(::header)
+            timeout {
+                requestTimeoutMillis = timeout
+                connectTimeoutMillis = timeout
+                socketTimeoutMillis = timeout
             }
         }
 
@@ -52,20 +51,28 @@ class HttpRequest(private val timeout: Long = 60_000) {
         return response
     }
 
-    suspend fun post(url: String, headers: Map<String, String> = emptyMap(), body: Any? = null): HttpResponse {
+    suspend fun post(url: String, headers: Map<String, String> = emptyMap(), body: Any? = null, timeout: Long = 60_000): HttpResponse {
         logger.info("Making request to $url... (POST)")
         val start = System.currentTimeMillis()
 
-        val response = httpClient().use {
-            if (body is List<*> && body.all { element -> element is PartData }) {
-                @Suppress("UNCHECKED_CAST")
-                it.submitFormWithBinaryData(url, body as List<PartData>) {
-                    headers.forEach(::header)
+        val response = if (body is List<*> && body.all { element -> element is PartData }) {
+            @Suppress("UNCHECKED_CAST")
+            client.submitFormWithBinaryData(url, body as List<PartData>) {
+                headers.forEach(::header)
+                timeout {
+                    requestTimeoutMillis = timeout
+                    connectTimeoutMillis = timeout
+                    socketTimeoutMillis = timeout
                 }
-            } else {
-                it.post(url) {
-                    headers.forEach(::header)
-                    body?.let(::setBody)
+            }
+        } else {
+            client.post(url) {
+                headers.forEach(::header)
+                body?.let(::setBody)
+                timeout {
+                    requestTimeoutMillis = timeout
+                    connectTimeoutMillis = timeout
+                    socketTimeoutMillis = timeout
                 }
             }
         }
@@ -74,52 +81,50 @@ class HttpRequest(private val timeout: Long = 60_000) {
         return response
     }
 
-    suspend fun getCookies(url: String): Pair<Document, Map<String, String>> {
-        val response = get(url)
+    suspend fun getCookies(url: String, timeout: Long = 60_000): Pair<Document, Map<String, String>> {
+        val response = get(url, timeout = timeout)
         return Jsoup.parse(response.bodyAsText()) to response.setCookie().associate { it.name to it.value }
     }
 
-    companion object {
-        suspend fun <T> retry(
-            times: Int,
-            delay: Long = 500,
-            shouldRetry: (Exception) -> Boolean = { true },
-            operation: suspend () -> T
-        ): T {
-            var lastException: Exception? = null
+    suspend fun <T> retry(
+        times: Int,
+        delay: Long = 500,
+        shouldRetry: (Exception) -> Boolean = { true },
+        operation: suspend () -> T
+    ): T {
+        var lastException: Exception? = null
 
-            repeat(times) { attempt ->
-                try {
-                    return operation()
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
+        repeat(times) { attempt ->
+            try {
+                return operation()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
 
-                    if (!shouldRetry(e)) throw e
+                if (!shouldRetry(e)) throw e
 
-                    lastException = e
-                    val attemptNum = attempt + 1
+                lastException = e
+                val attemptNum = attempt + 1
 
-                    logger.warning("Attempt $attemptNum failed: ${e.message}")
+                logger.warning("Attempt $attemptNum failed: ${e.message}")
 
-                    if (attempt < times - 1) {
-                        logger.warning("Retrying in $delay ms...")
-                        delay(delay.milliseconds)
-                    }
+                if (attempt < times - 1) {
+                    logger.warning("Retrying in $delay ms...")
+                    delay(delay.milliseconds)
                 }
             }
-
-            throw lastException ?: Exception("Failed after $times attempts")
         }
 
-        suspend fun <T> retryOnTimeout(
-            times: Int,
-            delay: Long = 500,
-            operation: suspend () -> T
-        ) = retry(
-            times = times,
-            delay = delay,
-            shouldRetry = { it is HttpRequestTimeoutException },
-            operation = operation
-        )
+        throw lastException ?: Exception("Failed after $times attempts")
     }
+
+    suspend fun <T> retryOnTimeout(
+        times: Int,
+        delay: Long = 500,
+        operation: suspend () -> T
+    ) = retry(
+        times = times,
+        delay = delay,
+        shouldRetry = { it is HttpRequestTimeoutException },
+        operation = operation
+    )
 }

--- a/src/main/kotlin/fr/shikkanime/wrappers/BskyWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/BskyWrapper.kt
@@ -39,10 +39,10 @@ object BskyWrapper {
 
     private const val BASE_URL = "https://bsky.social/xrpc"
     private val contentType = ContentType.Application.Json
-    private val httpRequest = HttpRequest()
+     
 
     suspend fun createSession(identifier: String, password: String): JsonObject {
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$BASE_URL/com.atproto.server.createSession",
             headers = mapOf(
                 HttpHeaders.ContentType to contentType.toString(),
@@ -61,7 +61,7 @@ object BskyWrapper {
     }
 
     suspend fun uploadBlob(accessJwt: String, contentType: ContentType, content: ByteArray): JsonObject {
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$BASE_URL/com.atproto.repo.uploadBlob",
             headers = mapOf(
                 HttpHeaders.ContentType to contentType.toString(),
@@ -125,7 +125,7 @@ object BskyWrapper {
         }
 
         if (embed != null) {
-            val (title, description, image) = Jsoup.parse(httpRequest.get(embed).bodyAsText()).run {
+            val (title, description, image) = Jsoup.parse(HttpRequest.get(embed).bodyAsText()).run {
                 Triple(
                     select("meta[property=og:title]").attr("content"),
                     select("meta[property=og:description]").attr("content"),
@@ -137,7 +137,7 @@ object BskyWrapper {
                 uploadBlob(
                     accessJwt,
                     ContentType.Image.JPEG,
-                    httpRequest.get(image).readRawBytes()
+                    HttpRequest.get(image).readRawBytes()
                 )
             }
 
@@ -152,7 +152,7 @@ object BskyWrapper {
             ))
         }
 
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$BASE_URL/com.atproto.repo.createRecord",
             headers = mapOf(
                 HttpHeaders.ContentType to contentType.toString(),

--- a/src/main/kotlin/fr/shikkanime/wrappers/ThreadsWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/ThreadsWrapper.kt
@@ -18,7 +18,6 @@ object ThreadsWrapper {
     private const val AUTHORIZATION_URL = "https://www.threads.net"
     private const val API_URL = "https://graph.threads.net"
     private const val API_VERSION = "v1.0"
-    private val httpRequest = HttpRequest()
 
     private fun getRedirectUri() = "${Constant.baseUrl}$ADMIN/api/threads".replace("http://", "https://")
 
@@ -29,7 +28,7 @@ object ThreadsWrapper {
             "scope=threads_basic,threads_content_publish"
 
     suspend fun getAccessToken(appId: String, appSecret: String, code: String): String {
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$API_URL/oauth/access_token?" +
                     "client_id=$appId&" +
                     "client_secret=$appSecret&" +
@@ -44,7 +43,7 @@ object ThreadsWrapper {
     }
 
     suspend fun getLongLivedAccessToken(appSecret: String, accessToken: String): String {
-        val response = httpRequest.get(
+        val response = HttpRequest.get(
             "$API_URL/access_token?" +
                     "client_secret=$appSecret&" +
                     "access_token=$accessToken&" +
@@ -74,7 +73,7 @@ object ThreadsWrapper {
         }.map { (key, value) -> "$key=$value" }
             .joinToString("&")
 
-        val createResponse = httpRequest.post(
+        val createResponse = HttpRequest.post(
             "$API_URL/$API_VERSION/me/threads?$parameters",
             headers = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString())
         )
@@ -82,7 +81,7 @@ object ThreadsWrapper {
         require(createResponse.status == HttpStatusCode.OK) { "Failed to post (${createResponse.status.value} - ${createResponse.bodyAsText()})" }
         val creationId = ObjectParser.fromJson(createResponse.bodyAsText())["id"].asString
 
-        val publishResponse = httpRequest.post(
+        val publishResponse = HttpRequest.post(
             "$API_URL/$API_VERSION/me/threads_publish?access_token=$accessToken&creation_id=$creationId",
             headers = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString())
         )

--- a/src/main/kotlin/fr/shikkanime/wrappers/TwitterWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/TwitterWrapper.kt
@@ -36,7 +36,6 @@ object TwitterWrapper {
     private const val ALGORITHM = "HmacSHA1"
     private val secureRandom = SecureRandom()
     private val charset = StandardCharsets.UTF_8
-    private val httpRequest = HttpRequest()
     private const val CHUNK_SIZE = 2 * 1024 * 1024
 
     private fun generateSignature(
@@ -92,7 +91,7 @@ object TwitterWrapper {
         mediaType: MediaType,
         totalBytes: Long
     ): String {
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$API_URL/media/upload/initialize",
             headers = mapOf(
                 HttpHeaders.ContentType to ContentType.Application.Json.toString(),
@@ -118,7 +117,7 @@ object TwitterWrapper {
         fileName: String,
         segment: ByteArray,
     ) {
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$API_URL/media/upload/$mediaId/append",
             headers = mapOf(
                 HttpHeaders.ContentType to ContentType.MultiPart.FormData.toString(),
@@ -139,7 +138,7 @@ object TwitterWrapper {
         authParams: AuthParams,
         mediaId: String,
     ) {
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$API_URL/media/upload/$mediaId/finalize",
             headers = mapOf(
                 HttpHeaders.ContentType to ContentType.Application.Json.toString(),
@@ -180,7 +179,7 @@ object TwitterWrapper {
             text?.let { put("text", it) }
         }
 
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$API_URL/tweets",
             headers = mapOf(
                 HttpHeaders.ContentType to ContentType.Application.Json.toString(),

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractAniListWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractAniListWrapper.kt
@@ -1,6 +1,5 @@
 package fr.shikkanime.wrappers.factories
 
-import fr.shikkanime.utils.HttpRequest
 import java.io.Serializable
 
 abstract class AbstractAniListWrapper {
@@ -70,7 +69,6 @@ abstract class AbstractAniListWrapper {
     }
 
     protected val baseUrl = "https://graphql.anilist.co"
-    protected val httpRequest = HttpRequest()
 
     abstract suspend fun search(query: String, page: Int = 1, limit: Int = 5, status: List<Status> = listOf(Status.RELEASING, Status.FINISHED)): Array<Media>
     abstract suspend fun getMediaById(id: Int): Media

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractAnimationDigitalNetworkWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractAnimationDigitalNetworkWrapper.kt
@@ -69,7 +69,6 @@ abstract class AbstractAnimationDigitalNetworkWrapper {
     }
 
     protected val baseUrl = "https://gw.api.animationdigitalnetwork.com/"
-    protected val httpRequest = HttpRequest()
 
     protected suspend fun HttpRequest.getWithHeaders(countryCode: CountryCode, url: String) = getWithHeaders(countryCode.name, url)
     protected suspend fun HttpRequest.getWithHeaders(country: String, url: String) = get(url, headers = mapOf("X-Source" to "Web", "X-Target-Distribution" to country.lowercase()))

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractCrunchyrollWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractCrunchyrollWrapper.kt
@@ -235,7 +235,6 @@ abstract class AbstractCrunchyrollWrapper {
     )
 
     protected val baseUrl = "https://www.crunchyroll.com/"
-    protected val httpRequest = HttpRequest()
     private val configCacheService by lazy { Constant.injector.getInstance(ConfigCacheService::class.java) }
 
     @Synchronized
@@ -247,7 +246,7 @@ abstract class AbstractCrunchyrollWrapper {
         key = StringUtils.EMPTY_STRING
     ) {
         runBlocking {
-            val response = httpRequest.post(
+            val response = HttpRequest.post(
                 "${baseUrl}auth/v1/token",
                 headers = mapOf(
                     HttpHeaders.ContentType to ContentType.Application.FormUrlEncoded.toString(),

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractDisneyPlusWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractDisneyPlusWrapper.kt
@@ -78,7 +78,6 @@ abstract class AbstractDisneyPlusWrapper {
     }
 
     protected val baseUrl = "https://disney.api.edge.bamgrid.com/"
-    protected val httpRequest = HttpRequest()
 
     @Synchronized
     private fun getAccessToken() = MapCache.getOrCompute(
@@ -91,7 +90,7 @@ abstract class AbstractDisneyPlusWrapper {
         val configCacheService = Constant.injector.getInstance(ConfigCacheService::class.java)
 
         runBlocking {
-            val response = httpRequest.post(
+            val response = HttpRequest.post(
                 "${baseUrl}graph/v1/device/graphql",
                 headers = mapOf(HttpHeaders.Authorization to (configCacheService.getValueAsString(ConfigPropertyKey.DISNEY_PLUS_AUTHORIZATION) ?: StringUtils.EMPTY_STRING)),
                 body = ObjectParser.toJson(

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractLiveChartWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractLiveChartWrapper.kt
@@ -1,12 +1,10 @@
 package fr.shikkanime.wrappers.factories
 
 import fr.shikkanime.entities.enums.Platform
-import fr.shikkanime.utils.HttpRequest
 import java.time.LocalDate
 
 abstract class AbstractLiveChartWrapper {
     protected val baseUrl = "https://www.livechart.me"
-    protected val httpRequest = HttpRequest()
 
     abstract suspend fun getAnimeIdsFromDate(date: LocalDate): Array<String>
     abstract suspend fun getStreamsByAnimeId(animeId: String): HashMap<Platform, Set<String>>

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractNetflixWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractNetflixWrapper.kt
@@ -82,7 +82,6 @@ abstract class AbstractNetflixWrapper {
 
     protected val baseUrl = "https://www.netflix.com"
     private val apiUrl = "https://web.prod.cloud.netflix.com/graphql"
-    protected val httpRequest = HttpRequest()
 
     private fun decodeUtf8(input: String) = input.replace("""\\x([0-9A-Fa-f]{2})""".toRegex()) { matchResult ->
         val hexCode = matchResult.groupValues[1]
@@ -96,7 +95,7 @@ abstract class AbstractNetflixWrapper {
         typeToken = object : TypeToken<MapCacheValue<NetflixAuthentification>>() {},
         key = StringUtils.EMPTY_STRING
     ) {
-        val (document, cookies) = httpRequest.getCookies(baseUrl)
+        val (document, cookies) = HttpRequest.getCookies(baseUrl)
 
         return@getOrComputeAsync NetflixAuthentification(
             requireNotNull(cookies["NetflixId"]),

--- a/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractPrimeVideoWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/factories/AbstractPrimeVideoWrapper.kt
@@ -3,7 +3,6 @@ package fr.shikkanime.wrappers.factories
 import com.google.gson.JsonObject
 import fr.shikkanime.entities.enums.CountryCode
 import fr.shikkanime.entities.enums.EpisodeType
-import fr.shikkanime.utils.HttpRequest
 import java.io.Serializable
 
 abstract class AbstractPrimeVideoWrapper {
@@ -42,7 +41,6 @@ abstract class AbstractPrimeVideoWrapper {
     ) : Serializable
 
     protected val baseUrl = "https://www.primevideo.com"
-    protected val httpRequest = HttpRequest()
 
     abstract suspend fun getShow(locale: String, id: String): Show
     abstract suspend fun getEpisodesByShowId(countryCode: CountryCode, id: String): Array<Episode>

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/AniListWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/AniListWrapper.kt
@@ -1,4 +1,5 @@
 package fr.shikkanime.wrappers.impl
+import fr.shikkanime.utils.HttpRequest
 
 import fr.shikkanime.utils.LoggerFactory
 import fr.shikkanime.utils.ObjectParser
@@ -79,7 +80,7 @@ object AniListWrapper : AbstractAniListWrapper() {
         status: List<Status>
     ): Array<Media> {
         throttle()
-        val response = httpRequest.post(baseUrl, mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()), ObjectParser.toJson(
+        val response = HttpRequest.post(baseUrl, mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()), ObjectParser.toJson(
             mapOf(
                 "query" to $$"""
                     query ($search: String, $page: Int, $perPage: Int, $statusIn: [MediaStatus]) {
@@ -110,7 +111,7 @@ object AniListWrapper : AbstractAniListWrapper() {
 
     override suspend fun getMediaById(id: Int): Media {
         throttle()
-        val response = httpRequest.post(baseUrl, mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()), ObjectParser.toJson(
+        val response = HttpRequest.post(baseUrl, mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()), ObjectParser.toJson(
             mapOf(
                 "query" to $$"""
                     query Media($mediaId: Int) {

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/AnimationDigitalNetworkWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/AnimationDigitalNetworkWrapper.kt
@@ -1,6 +1,7 @@
 package fr.shikkanime.wrappers.impl
 
 import fr.shikkanime.entities.enums.CountryCode
+import fr.shikkanime.utils.HttpRequest
 import fr.shikkanime.utils.ObjectParser
 import fr.shikkanime.wrappers.factories.AbstractAnimationDigitalNetworkWrapper
 import io.ktor.client.statement.*
@@ -9,28 +10,28 @@ import java.time.LocalDate
 
 object AnimationDigitalNetworkWrapper : AbstractAnimationDigitalNetworkWrapper() {
     override suspend fun getLatestVideos(countryCode: CountryCode, date: LocalDate): Array<Video> {
-        val response = httpRequest.getWithHeaders(countryCode, "${baseUrl}video/calendar?date=$date")
+        val response = HttpRequest.getWithHeaders(countryCode, "${baseUrl}video/calendar?date=$date")
         require(response.status == HttpStatusCode.OK) { "Failed to get media list (${response.status.value})" }
         val videos = ObjectParser.fromJson(response.bodyAsText()).getAsJsonArray("videos") ?: throw Exception("Failed to get media list")
         return ObjectParser.fromJson(videos, Array<Video>::class.java)
     }
 
     override suspend fun getShow(country: String, id: Int): Show {
-        val response = httpRequest.getWithHeaders(country, "${baseUrl}show/$id?withMicrodata=true")
+        val response = HttpRequest.getWithHeaders(country, "${baseUrl}show/$id?withMicrodata=true")
         require(response.status == HttpStatusCode.OK) { "Failed to get show (${response.status.value})" }
         val showJson = ObjectParser.fromJson(response.bodyAsText()).getAsJsonObject("show") ?: throw Exception("Failed to get show")
         return ObjectParser.fromJson(showJson, Show::class.java)
     }
 
     override suspend fun getShowVideos(countryCode: CountryCode, id: Int): Array<Video> {
-        val response = httpRequest.getWithHeaders(countryCode, "${baseUrl}video/show/$id?order=asc&limit=-1")
+        val response = HttpRequest.getWithHeaders(countryCode, "${baseUrl}video/show/$id?order=asc&limit=-1")
         require(response.status == HttpStatusCode.OK) { "Failed to get show videos (${response.status.value})" }
         val videosJson = ObjectParser.fromJson(response.bodyAsText()).getAsJsonArray("videos") ?: throw Exception("Failed to get videos")
         return ObjectParser.fromJson(videosJson, Array<Video>::class.java)
     }
 
     override suspend fun getVideo(countryCode: CountryCode, id: Int): Video {
-         val response = httpRequest.getWithHeaders(countryCode, "${baseUrl}video/$id/public")
+         val response = HttpRequest.getWithHeaders(countryCode, "${baseUrl}video/$id/public")
         require(response.status == HttpStatusCode.OK) { "Failed to get video (${response.status.value})" }
         val videoJson = ObjectParser.fromJson(response.bodyAsText()).getAsJsonObject("video") ?: throw Exception("Failed to get video")
         return ObjectParser.fromJson(videoJson, Video::class.java)

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/CrunchyrollWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/CrunchyrollWrapper.kt
@@ -1,4 +1,5 @@
 package fr.shikkanime.wrappers.impl
+import fr.shikkanime.utils.HttpRequest
 
 import fr.shikkanime.utils.ObjectParser
 import fr.shikkanime.utils.StringUtils
@@ -16,7 +17,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         start: Int,
         simulcast: String?
     ): List<BrowseObject> {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/discover/browse?sort_by=${sortBy.name.lowercase()}&type=${type.name.lowercase()}&n=$size&start=$start&locale=$locale${if (simulcast != null) "&seasonal_tag=$simulcast" else StringUtils.EMPTY_STRING}")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/discover/browse?sort_by=${sortBy.name.lowercase()}&type=${type.name.lowercase()}&n=$size&start=$start&locale=$locale${if (simulcast != null) "&seasonal_tag=$simulcast" else StringUtils.EMPTY_STRING}")
         require(response.status == HttpStatusCode.OK) { "Failed to get media list (${response.status.value})" }
         return response.body<CrunchyrollResponse<BrowseObject>>().data
     }
@@ -25,7 +26,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         locale: String,
         id: String
     ): Series {
-         val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/cms/series/$id?locale=$locale")
+         val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/cms/series/$id?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get series (${response.status.value})" }
         val asJsonArray = ObjectParser.fromJson(response.bodyAsText()).getAsJsonArray("data") ?: throw Exception("Failed to get series")
         return ObjectParser.fromJson(asJsonArray.first(), Series::class.java)
@@ -35,7 +36,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         locale: String,
         id: String
     ): Array<Season> {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/cms/series/$id/seasons?locale=$locale")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/cms/series/$id/seasons?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get seasons with series id (${response.status.value})" }
         val asJsonArray = ObjectParser.fromJson(response.bodyAsText()).getAsJsonArray("data") ?: throw Exception("Failed to get seasons with series id")
         return ObjectParser.fromJson(asJsonArray, Array<Season>::class.java)
@@ -45,7 +46,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         locale: String,
         id: String
     ): Season {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/cms/seasons/$id?locale=$locale")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/cms/seasons/$id?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get season (${response.status.value})" }
         val asJsonArray = ObjectParser.fromJson(response.bodyAsText()).getAsJsonArray("data") ?: throw Exception("Failed to get season")
         return ObjectParser.fromJson(asJsonArray.first(), Season::class.java)
@@ -56,7 +57,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         locale: String,
         id: String
     ): Array<Episode> {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/cms/seasons/$id/episodes?locale=$locale")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/cms/seasons/$id/episodes?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get episodes by season id (${response.status.value})" }
         return response.body<CrunchyrollResponse<Episode>>().data.toTypedArray()
     }
@@ -68,7 +69,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         locale: String,
         id: String
     ): Episode {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/cms/episodes/$id?locale=$locale")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/cms/episodes/$id?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get episode (${response.status.value})" }
         val asJsonArray = ObjectParser.fromJson(response.bodyAsText()).getAsJsonArray("data") ?: throw Exception("Failed to get episode")
         return ObjectParser.fromJson(asJsonArray.first(), Episode::class.java)
@@ -82,7 +83,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         type: String,
         id: String
     ): BrowseObject {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/discover/$type/$id?locale=$locale")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/discover/$type/$id?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get $type episode (${response.status.value})" }
         return response.body<CrunchyrollResponse<Playhead>>().data.first().panel
     }
@@ -94,7 +95,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
         locale: String,
         vararg ids: String
     ): List<BrowseObject> {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v2/cms/objects/${ids.joinToString(StringUtils.COMMA_STRING)}?locale=$locale")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v2/cms/objects/${ids.joinToString(StringUtils.COMMA_STRING)}?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get objects (${response.status.value})" }
         return response.body<CrunchyrollResponse<BrowseObject>>().data
     }
@@ -109,7 +110,7 @@ object CrunchyrollWrapper : AbstractCrunchyrollWrapper() {
     ) = getEpisodesBySeriesIdBase(locale, id, original)
 
     override suspend fun getSimulcasts(locale: String): Array<Simulcast> {
-        val response = httpRequest.getWithAccessToken("${baseUrl}content/v1/season_list?locale=$locale")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}content/v1/season_list?locale=$locale")
         require(response.status == HttpStatusCode.OK) { "Failed to get simulcasts (${response.status.value})" }
         val asJsonArray = ObjectParser.fromJson(response.bodyAsText()).getAsJsonArray("items") ?: throw Exception("Failed to get simulcasts")
         return ObjectParser.fromJson(asJsonArray, Array<Simulcast>::class.java)

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/DisneyPlusWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/DisneyPlusWrapper.kt
@@ -2,6 +2,7 @@ package fr.shikkanime.wrappers.impl
 
 import fr.shikkanime.entities.enums.CountryCode
 import fr.shikkanime.entities.enums.Locale
+import fr.shikkanime.utils.HttpRequest
 import fr.shikkanime.utils.LocaleUtils
 import fr.shikkanime.utils.ObjectParser
 import fr.shikkanime.utils.ObjectParser.getAsBoolean
@@ -17,7 +18,7 @@ object DisneyPlusWrapper : AbstractDisneyPlusWrapper() {
     private const val API_VERSION = "v1.15"
 
     override suspend fun getLatestShowIds(): Array<String> {
-        val response = httpRequest.getWithAccessToken("${baseUrl}explore/$API_VERSION/set/c6cc13eb-14ad-42fd-82b4-6d959032996c?limit=5&offset=0&pageId=00ef9b51-0ed0-4883-b1e4-fd5a075c7f54")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}explore/$API_VERSION/set/c6cc13eb-14ad-42fd-82b4-6d959032996c?limit=5&offset=0&pageId=00ef9b51-0ed0-4883-b1e4-fd5a075c7f54")
         require(response.status == HttpStatusCode.OK) { "Failed to fetch latest show ids (${response.status.value})" }
         return ObjectParser.fromJson(response.bodyAsText())
             .getAsJsonObject("data")
@@ -33,7 +34,7 @@ object DisneyPlusWrapper : AbstractDisneyPlusWrapper() {
     }
 
     override suspend fun getShow(id: String): Show {
-        val response = httpRequest.getWithAccessToken("${baseUrl}explore/$API_VERSION/page/entity-$id?disableSmartFocus=true&enhancedContainersLimit=15&limit=15")
+        val response = HttpRequest.getWithAccessToken("${baseUrl}explore/$API_VERSION/page/entity-$id?disableSmartFocus=true&enhancedContainersLimit=15&limit=15")
         require(response.status == HttpStatusCode.OK) { "Failed to fetch show (${response.status.value})" }
         val jsonObject = ObjectParser.fromJson(response.bodyAsText())
             .getAsJsonObject("data")
@@ -89,7 +90,7 @@ object DisneyPlusWrapper : AbstractDisneyPlusWrapper() {
             var hasMore: Boolean
 
             do {
-                val response = httpRequest.getWithAccessToken("${baseUrl}explore/$API_VERSION/season/$seasonId?limit=24&offset=${(page++ - 1) * 24}")
+                val response = HttpRequest.getWithAccessToken("${baseUrl}explore/$API_VERSION/season/$seasonId?limit=24&offset=${(page++ - 1) * 24}")
                 require(response.status == HttpStatusCode.OK) { "Failed to fetch episodes (${response.status.value})" }
 
                 val jsonObject = ObjectParser.fromJson(response.bodyAsText())
@@ -171,7 +172,7 @@ object DisneyPlusWrapper : AbstractDisneyPlusWrapper() {
             "playbackId": "$resourceId"
         }""".trimIndent()
 
-        val response = httpRequest.postWithAccessToken(
+        val response = HttpRequest.postWithAccessToken(
             "${baseUrl}v7/playback/ctr-regular",
             headers,
             body

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/LiveChartWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/LiveChartWrapper.kt
@@ -1,6 +1,7 @@
 package fr.shikkanime.wrappers.impl
 
 import fr.shikkanime.entities.enums.Platform
+import fr.shikkanime.utils.HttpRequest
 import fr.shikkanime.utils.ObjectParser
 import fr.shikkanime.utils.ObjectParser.getAsString
 import fr.shikkanime.utils.atStartOfWeek
@@ -15,7 +16,7 @@ object LiveChartWrapper : AbstractLiveChartWrapper() {
     private val platformIdRegex = "https://(?:www\\.)?(?:animationdigitalnetwork|crunchyroll|disneyplus|netflix|primevideo)\\.com/[a-z-]+/(?:entity-)?([^/]+)".toRegex()
 
     override suspend fun getAnimeIdsFromDate(date: LocalDate): Array<String> {
-        val response = httpRequest.get(
+        val response = HttpRequest.get(
             "$baseUrl/schedule?date=${date.atStartOfWeek()}&layout=full&sort=release_date&start=monday",
             mapOf(
                 HttpHeaders.Accept to ContentType.Text.Html.toString(),
@@ -53,7 +54,7 @@ object LiveChartWrapper : AbstractLiveChartWrapper() {
             )
         )
 
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$baseUrl/graphql",
             mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()),
             payload

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/NetflixWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/NetflixWrapper.kt
@@ -35,7 +35,7 @@ object NetflixWrapper : AbstractNetflixWrapper() {
         val netflixId = configCacheService.getValueAsString(ConfigPropertyKey.NETFLIX_ID)
         val netflixSecureId = configCacheService.getValueAsString(ConfigPropertyKey.NETFLIX_SECURE_ID)
         require(netflixId?.isNotBlank() == true && netflixSecureId?.isNotBlank() == true) { "NetflixId and NetflixSecureId must be set in the configuration" }
-        val authUrl = extractAuthUrl(httpRequest.get(baseUrl, mapOf(HttpHeaders.Cookie to getCookieValue(netflixId, netflixSecureId))).bodyAsText())
+        val authUrl = extractAuthUrl(HttpRequest.get(baseUrl, mapOf(HttpHeaders.Cookie to getCookieValue(netflixId, netflixSecureId))).bodyAsText())
         NetflixAuthentification(netflixId, netflixSecureId, authUrl)
     }
 
@@ -50,7 +50,7 @@ object NetflixWrapper : AbstractNetflixWrapper() {
     private suspend fun getMetadata(id: Int): ShowMetadata {
         val netflixAuthentification = getNetflixAuthentificationFromConfig()
 
-        val response = httpRequest.get(
+        val response = HttpRequest.get(
             "$baseUrl/nq/website/memberapi/release/metadata?movieid=$id&imageFormat=jpg",
             mapOf(
                 HttpHeaders.ContentType to ContentType.Application.Json.toString(),
@@ -81,7 +81,7 @@ object NetflixWrapper : AbstractNetflixWrapper() {
 
     override suspend fun getLatestShows(): Array<LatestShow> {
         val netflixAuthentification = getNetflixAuthentificationFromConfig()
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$baseUrl/nq/website/memberapi/release/pathEvaluator?isTop10Supported=true&original_path=%2Fshakti%2Fmre%2FpathEvaluator",
             mapOf(HttpHeaders.Cookie to getCookieValue(netflixAuthentification.id, netflixAuthentification.secureId)),
             FormDataContent(
@@ -114,7 +114,7 @@ object NetflixWrapper : AbstractNetflixWrapper() {
     }
 
     override suspend fun getShow(locale: String, id: Int): Show {
-        val response = httpRequest.postGraphQL(locale, ObjectParser.toJson(mapOf(
+        val response = HttpRequest.postGraphQL(locale, ObjectParser.toJson(mapOf(
             "operationName" to "DetailModal",
             "variables" to mapOf(
                 "opaqueImageFormat" to "PNG",
@@ -174,7 +174,7 @@ object NetflixWrapper : AbstractNetflixWrapper() {
     }
 
     private suspend fun fetchSeasonsData(countryCode: CountryCode, id: Int, seasonCount: Int): HttpResponse {
-        val seasonsResponse = httpRequest.postGraphQL(countryCode, ObjectParser.toJson(mapOf(
+        val seasonsResponse = HttpRequest.postGraphQL(countryCode, ObjectParser.toJson(mapOf(
             "operationName" to "PreviewModalEpisodeSelector",
             "variables" to mapOf(
                 "showId" to id,
@@ -254,7 +254,7 @@ object NetflixWrapper : AbstractNetflixWrapper() {
     }
 
     private suspend fun fetchAndCreateEpisodesForSeason(countryCode: CountryCode, show: Show, season: Season, seasonNumber: Int): List<Episode> {
-        val response = httpRequest.postGraphQL(countryCode, ObjectParser.toJson(mapOf(
+        val response = HttpRequest.postGraphQL(countryCode, ObjectParser.toJson(mapOf(
             "operationName" to "PreviewModalEpisodeSelectorSeasonEpisodes",
             "variables" to mapOf(
                 "seasonId" to season.id,
@@ -330,7 +330,7 @@ object NetflixWrapper : AbstractNetflixWrapper() {
 
     suspend fun getEpisodeAudioTrackList(countryCode: CountryCode, vararg ids: Int): Map<Int, Set<String>> {
         val netflixAuthentification = getNetflixAuthentificationFromConfig()
-        val response = httpRequest.post(
+        val response = HttpRequest.post(
             "$baseUrl/nq/website/memberapi/release/pathEvaluator?method=call&original_path=%2Fshakti%2Fmre%2FpathEvaluator",
             mapOf(HttpHeaders.Cookie to getCookieValue(netflixAuthentification.id, netflixAuthentification.secureId)),
             FormDataContent(

--- a/src/main/kotlin/fr/shikkanime/wrappers/impl/PrimeVideoWrapper.kt
+++ b/src/main/kotlin/fr/shikkanime/wrappers/impl/PrimeVideoWrapper.kt
@@ -190,7 +190,7 @@ object PrimeVideoWrapper : AbstractPrimeVideoWrapper() {
     }
 
     private suspend fun fetchPrimeVideoData(url: String, locale: String): JsonObject {
-        val response = httpRequest.get(
+        val response = HttpRequest.get(
             "$url?dvWebAppClientVersion=1.0.121090.",
             headers = mapOf(
                 HttpHeaders.Accept to ContentType.Application.Json.toString(),
@@ -207,7 +207,7 @@ object PrimeVideoWrapper : AbstractPrimeVideoWrapper() {
     }
 
     private suspend fun loadMoreData(id: String, token: String): JsonObject {
-        val response = httpRequest.get(
+        val response = HttpRequest.get(
             "$baseUrl/api/getDetailWidgets?titleID=$id&widgets=${URLEncoder.encode("[{\"widgetType\":\"EpisodeList\",\"widgetToken\":\"$token\"}]", StandardCharsets.UTF_8)}",
             headers = mapOf("Accept" to ContentType.Application.Json.toString())
         )

--- a/src/main/resources/assets/js/dashboard_chart.js
+++ b/src/main/resources/assets/js/dashboard_chart.js
@@ -3,6 +3,7 @@ const activedaysmenuElement = document.getElementById('activedaysmenu');
 const daysmenuElement = document.getElementById('daysmenu');
 const cpuChartElement = document.getElementById('cpuLoadChart').getContext('2d');
 const memoryChartElement = document.getElementById('memoryUsageChart').getContext('2d');
+const threadCountChartElement = document.getElementById('threadCountChart').getContext('2d');
 const attachmentsChartElement = document.getElementById('attachmentsChart').getContext('2d');
 const versionsPieElement = document.getElementById('versionsPie').getContext('2d');
 const localesPieElement = document.getElementById('localesPie').getContext('2d');
@@ -39,6 +40,38 @@ const createPieChart = (element, label) => new Chart(element, {
 
 const cpuChart = createLineChart(cpuChartElement, '% CPU', 'hour');
 const memoryChart = createLineChart(memoryChartElement, 'RAM in MB', 'hour');
+const threadCountChart = new Chart(threadCountChartElement, {
+    type: 'line',
+    data: {
+        labels: [],
+        datasets: [
+            {
+                label: 'Avg Threads',
+                data: [],
+                borderColor: 'rgba(33,37,41, 1)',
+                backgroundColor: 'rgba(33,37,41,0.1)',
+                tension: 0.1,
+                fill: true
+            },
+            {
+                label: 'Peak Threads',
+                data: [],
+                borderColor: 'rgba(225, 87, 89, 1)',
+                backgroundColor: 'rgba(225, 87, 89, 0.1)',
+                borderDash: [5, 5],
+                tension: 0.1,
+                fill: false
+            }
+        ]
+    },
+    options: {
+        maintainAspectRatio: false,
+        scales: { x: { type: 'time', time: { unit: 'hour' } }, y: { beginAtZero: true } },
+        elements: { point: { radius: 0 } },
+        animation: { duration: 0 },
+        plugins: { legend: { display: false } }
+    }
+});
 const attachmentsChart = createLineChart(attachmentsChartElement, 'Attachments', 'day');
 const versionsPie = createPieChart(versionsPieElement, 'Versions');
 const localesPie = createPieChart(localesPieElement, 'Locales');
@@ -79,7 +112,7 @@ function updateMetricsChart() {
         const labels = data.map(m => m.date);
         const toNumberArray = (arr, key) => arr.map(m => parseFloat(m[key]));
 
-        [cpuChart, memoryChart].forEach(c => c.options.scales.x.time.unit = timeUnit);
+        [cpuChart, memoryChart, threadCountChart].forEach(c => c.options.scales.x.time.unit = timeUnit);
 
         cpuChart.data.labels = labels;
         cpuChart.data.datasets[0].data = toNumberArray(data, 'avgCpuLoad');
@@ -88,6 +121,11 @@ function updateMetricsChart() {
         memoryChart.data.labels = labels;
         memoryChart.data.datasets[0].data = toNumberArray(data, 'avgMemoryUsage');
         memoryChart.update();
+
+        threadCountChart.data.labels = labels;
+        threadCountChart.data.datasets[0].data = toNumberArray(data, 'avgThreadCount');
+        threadCountChart.data.datasets[1].data = toNumberArray(data, 'maxPeakThreadCount');
+        threadCountChart.update();
     });
 }
 

--- a/src/main/resources/db/changelog/2026/05/01-changelog.xml
+++ b/src/main/resources/db/changelog/2026/05/01-changelog.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+    <property global="false" name="id" value="1777656839289"/>
+    <property global="false" name="author" value="Ziedelth"/>
+
+    <changeSet id="${id}-1" author="${author}">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="metric" columnName="thread_count"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="metric">
+            <column name="thread_count" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="${id}-2" author="${author}">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="metric" columnName="peak_thread_count"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="metric">
+            <column name="peak_thread_count" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -134,4 +134,6 @@
     <include file="/db/changelog/2026/03/05-changelog.xml"/>
     <!-- April 2026 -->
     <include file="/db/changelog/2026/04/01-changelog.xml"/>
-</databaseChangeLog>
+    <!-- May 2026 -->
+    <include file="/db/changelog/2026/05/01-changelog.xml"/>
+    </databaseChangeLog>

--- a/src/main/resources/templates/admin/dashboard.ftl
+++ b/src/main/resources/templates/admin/dashboard.ftl
@@ -43,7 +43,7 @@
     <div class="row g-2">
         <!-- Line charts group -->
         <!-- CPU time series -->
-        <div class="col-12 col-md-3">
+        <div class="col-12 col-md-2">
             <div class="card p-3">
                 <div style="height: 36vh">
                     <canvas id="cpuLoadChart"></canvas>
@@ -52,10 +52,19 @@
         </div>
 
         <!-- Memory time series -->
-        <div class="col-12 col-md-3">
+        <div class="col-12 col-md-2">
             <div class="card p-3">
                 <div style="height: 36vh">
                     <canvas id="memoryUsageChart"></canvas>
+                </div>
+            </div>
+        </div>
+
+        <!-- Thread count time series -->
+        <div class="col-12 col-md-2">
+            <div class="card p-3">
+                <div style="height: 36vh">
+                    <canvas id="threadCountChart"></canvas>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Introduced `thread_count` and `peak_thread_count` columns to `Metric` entity with accompanying database changes and backend updates.
- Updated `GroupedMetricDto` and `MetricRepository` to expose new thread metrics.
- Added `threadCountChart` to dashboard UI for visualizing thread metrics.
- Refactored `HttpRequest` into a singleton object for better memory efficiency and centralized configuration.
- Fixed redundant `HttpRequest` object instantiations across multiple wrapper classes.